### PR TITLE
ci(claude-review): allow bot-authored PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: '*'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
- Adds \`allowed_bots: '*'\` to the claude-code-review workflow.
- Without this, the action exits with: \`Workflow initiated by non-human actor: renovate (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.\` — preventing Claude from reviewing any Renovate dependency-update PR.

## Test plan
- [ ] Wait for next Renovate PR after merge; confirm \`claude-review\` runs and posts a review (no longer fails with bot block).