### PR TITLE
fix(payments): bump Stripe apiVersion to match installed SDK

### DIFF
--- a/packages/payments/index.ts
+++ b/packages/payments/index.ts
@@ -3,7 +3,7 @@ import Stripe from "stripe";
 import { keys } from "./keys";
 
 export const stripe = new Stripe(keys().STRIPE_SECRET_KEY, {
-  apiVersion: "2026-01-28.clover",
+  apiVersion: "2026-04-22.dahlia",
 });
 
 export type { Stripe } from "stripe";


### PR DESCRIPTION
## Summary
- Updates Stripe \`apiVersion\` from \`"2026-01-28.clover"\` to \`"2026-04-22.dahlia"\` so it matches the installed Stripe SDK v22's expected type.
- Discovered while typechecking \`apps/api\` after the recent dependency-update merges (#169, #170). The error \`Type '"2026-01-28.clover"' is not assignable to type '"2026-04-22.dahlia"'\` was a latent issue from a previous SDK bump.
- Only consumer is \`apps/api/app/webhooks/payments/route.ts\`, which uses event types (\`checkout.session.completed\`, \`subscription_schedule.canceled\`) that are stable across these Stripe API versions.

## Test plan
- [x] \`packages/payments\` typecheck passes
- [x] \`apps/api\` typecheck passes (the consumer)
- [x] All workspace tests pass