### PR TITLE
fix(web): hero asterisk hydration mismatch (React 19/Next 16) + amplifier copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -282,3 +282,6 @@ packages/database/generated
 
 # worktrees
 .worktrees/
+
+# Claude Code scheduled-tasks runtime lock (transient; .claude/settings.json stays tracked)
+.claude/scheduled_tasks.lock

--- a/apps/web/app/[locale]/components/hero-asterisk.tsx
+++ b/apps/web/app/[locale]/components/hero-asterisk.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@repo/design-system/components/ui/hover-card";
+
+// Kept as its own client component so the Radix HoverCard trigger isn't passed
+// as a Server Component child into the hero's <h1>. Doing so caused a React 19 /
+// Next 16 hydration mismatch that dropped the <sup> on the client.
+export function HeroAsterisk() {
+  return (
+    <HoverCard closeDelay={100} openDelay={100}>
+      <HoverCardTrigger asChild>
+        <sup className="ml-1 inline-block cursor-help align-top font-mono font-normal text-ht-cyan-700/70 text-xl tracking-normal hover:text-ht-cyan-700 sm:text-2xl dark:text-ht-cyan-300/85 dark:hover:text-ht-cyan-200">
+          *
+        </sup>
+      </HoverCardTrigger>
+      <HoverCardContent
+        align="start"
+        className="w-80 border-ht-cyan-700/20 dark:border-ht-cyan-500/30"
+        side="bottom"
+      >
+        <p className="font-mono text-ht-cyan-900/80 text-sm/6 dark:text-ht-cyan-300/90">
+          <span aria-hidden="true" className="select-none opacity-70">
+            *&nbsp;
+          </span>
+          AI doesn&apos;t make you better. It makes you bigger. It&apos;s an
+          amplifier, not a compass — it has no opinion on whether you&apos;re
+          pointed the right way.
+        </p>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/apps/web/app/[locale]/components/hero.tsx
+++ b/apps/web/app/[locale]/components/hero.tsx
@@ -1,10 +1,6 @@
-import {
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@repo/design-system/components/ui/hover-card";
 import { Separator } from "@repo/design-system/components/ui/separator";
 import { Container } from "./container";
+import { HeroAsterisk } from "./hero-asterisk";
 import { MarketingButton } from "./marketing-button";
 import { MetaAside } from "./meta-aside";
 import { Navbar } from "./navbar";
@@ -28,26 +24,7 @@ export function Hero() {
           </p>
           <h1 className="max-w-4xl font-display font-medium text-6xl/[0.95] text-foreground tracking-tight sm:text-7xl/[0.95] md:text-8xl/[0.95]">
             AI makes you more.
-            <HoverCard closeDelay={100} openDelay={100}>
-              <HoverCardTrigger asChild>
-                <sup className="ml-1 inline-block cursor-help align-top font-mono font-normal text-ht-cyan-700/70 text-xl tracking-normal hover:text-ht-cyan-700 sm:text-2xl dark:text-ht-cyan-300/85 dark:hover:text-ht-cyan-200">
-                  *
-                </sup>
-              </HoverCardTrigger>
-              <HoverCardContent
-                align="start"
-                className="w-80 border-ht-cyan-700/20 dark:border-ht-cyan-500/30"
-                side="bottom"
-              >
-                <p className="font-mono text-ht-cyan-900/80 text-sm/6 dark:text-ht-cyan-300/90">
-                  <span aria-hidden="true" className="select-none opacity-70">
-                    *&nbsp;
-                  </span>
-                  AI doesn&apos;t make you better. It makes you bigger.
-                  That&apos;s the good news and the warning.
-                </p>
-              </HoverCardContent>
-            </HoverCard>
+            <HeroAsterisk />
           </h1>
           <p className="mt-8 max-w-xl font-medium text-muted-foreground text-xl/8 sm:text-2xl/9">
             For developers who&apos;d rather own the answer than borrow it.
@@ -97,8 +74,9 @@ export function Hero() {
             <span aria-hidden="true" className="select-none opacity-70">
               *&nbsp;
             </span>
-            AI doesn&apos;t make you better. It makes you bigger. That&apos;s
-            the good news and the warning.
+            AI doesn&apos;t make you better. It makes you bigger. It&apos;s an
+            amplifier, not a compass — it has no opinion on whether you&apos;re
+            pointed the right way.
           </MetaAside>
         </div>
       </Container>


### PR DESCRIPTION
## What

Fixes a hydration mismatch in the marketing hero and lands the new asterisk copy.

## Root cause

The hero's asterisk hover-card **trigger** is a client component (`HoverCardTrigger asChild` → `<sup>`), but it was rendered as a child of the **Server Component** `<h1>`. Under React 19.2 / Next 16, the client dropped that server-passed `<sup>` during hydration → hydration mismatch. The `*` rendered from SSR, then vanished on hydrate.

That mismatch also forced React to re-render an ancestor subtree on the client, which re-rendered `next-themes`' inline `<script>` during a client render — tripping React 19.2's "Encountered a script tag while rendering React component" error. So the two console errors shared **one** root cause.

## Fix

- Extract the asterisk into its own `"use client"` component, `HeroAsterisk`, so the Radix trigger and its `<sup>` are created client-side and never cross the RSC boundary as server-passed children.
- `hero.tsx` stays a Server Component (no extra JS pulled into the client bundle for Navbar/buttons).
- Lands the amplifier/compass asterisk copy: *"AI doesn't make you better. It makes you bigger. It's an amplifier, not a compass — it has no opinion on whether you're pointed the right way."*

## Verification

Verified in a clean headless browser against the dev server:

- Asterisk renders and **survives hydration** (`<sup>` present, `supCount: 1`).
- **0 console errors** (both the hydration error and the script-tag error gone).
- Hover-card opens on hover and shows the copy.
- No Next.js error overlay.

## Housekeeping

Separate commit gitignores `.claude/scheduled_tasks.lock` (transient Claude Code scheduled-tasks lock), scoped to the file so the tracked `.claude/settings.json` is untouched.

## Note

This branch is behind `main` (Renovate dependency bumps only) — none of those commits touch the changed files, so the PR is conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
