### PR TITLE
fix(ci): stop Vercel building the entire.io checkpoints branch

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -2,3 +2,4 @@ tmp/
 settings.local.json
 metadata/
 logs/
+redactors/local/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,4 +1,10 @@
 {
   "enabled": true,
+  "strategy_options": {
+    "checkpoint_remote": {
+      "provider": "github",
+      "repo": "hasToggle/hasToggle.dev-checkpoints"
+    }
+  },
   "telemetry": false
 }

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "node scripts/skip-ci.js",
+  "git": {
+    "deploymentEnabled": {
+      "entire/*": false,
+      "entire/**": false
+    }
+  },
   "crons": [
     {
       "path": "/cron/keep-alive",

--- a/apps/app/vercel.json
+++ b/apps/app/vercel.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "node scripts/skip-ci.js"
+  "ignoreCommand": "node scripts/skip-ci.js",
+  "git": {
+    "deploymentEnabled": {
+      "entire/*": false,
+      "entire/**": false
+    }
+  }
 }

--- a/apps/storybook/vercel.json
+++ b/apps/storybook/vercel.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "node scripts/skip-ci.js"
+  "ignoreCommand": "node scripts/skip-ci.js",
+  "git": {
+    "deploymentEnabled": {
+      "entire/*": false,
+      "entire/**": false
+    }
+  }
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "node scripts/skip-ci.js"
+  "ignoreCommand": "node scripts/skip-ci.js",
+  "git": {
+    "deploymentEnabled": {
+      "entire/*": false,
+      "entire/**": false
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- entire.io pushes session transcripts to the data-only branch `entire/checkpoints/v1`; Vercel deploys every pushed branch, and since that branch has no `apps/web`, each push failed at `build-container-init` with `NOW_SANDBOX_WORKER_ROOTDIR_NOT_EXIST` — before the Ignored Build Step runs, so no ignore command could ever catch it.
- `.entire/settings.json` now sets `strategy_options.checkpoint_remote`, so checkpoints push to the private repo `hasToggle/hasToggle.dev-checkpoints` (same org, as entire requires). Existing history was migrated there (same SHA, `c84573f`) and the branch was deleted from this repo. Bonus: transcripts are redacted-but-plaintext and this repo is public — the private checkpoint repo closes that exposure.
- Added `git.deploymentEnabled: {"entire/*": false, "entire/**": false}` to each app's `vercel.json` so accidentally pushed entire shadow branches (which do contain these files) can't deploy either.

## After merging
- Pull in every clone/worktree (or run `entire configure --checkpoint-remote github:hasToggle/hasToggle.dev-checkpoints` there) so stale checkouts stop recreating the branch; if it reappears in the meantime: `git push origin --delete entire/checkpoints/v1`.
- Grant the Entire GitHub App access to `hasToggle.dev-checkpoints` so the entire.io web app can read checkpoint history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)