### PR TITLE
chore(renovate): block broken @radix-ui/react-slot 1.3.1 / radix-ui 1.6.5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,16 @@
       "rangeStrategy": "bump"
     },
     {
+      "description": "@radix-ui/react-slot@1.3.1 calls createContext at module scope without 'use client', crashing RSC builds (see radix-ui/primitives#3542). Drop this rule and the root package.json override once a fixed release ships.",
+      "matchPackageNames": ["@radix-ui/react-slot"],
+      "allowedVersions": "!/^1\\.3\\.1$/"
+    },
+    {
+      "description": "radix-ui@1.6.5 pins the broken @radix-ui/react-slot@1.3.1 — remove together with the rule above.",
+      "matchPackageNames": ["radix-ui"],
+      "allowedVersions": "!/^1\\.6\\.5$/"
+    },
+    {
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": true,
       "groupName": "patch updates"


### PR DESCRIPTION
## Why

`@radix-ui/react-slot@1.3.1` (published 2026-07-22) adds a module-scope `React.createContext` without a `"use client"` directive. Any server component importing `Slot` (e.g. the design-system `button.tsx`) crashes `next build` during page-data collection with `TypeError: createContext is not a function`. `radix-ui@1.6.5` pins that exact slot version. Upstream bug class: radix-ui/primitives#3542; no fixed stable release exists yet (only 1.4.0 RCs).

This broke the web build in #311 (fixed there by pinning `radix-ui@1.6.4` + a root override to slot 1.3.0) and again in #313 (fixed via rebase onto the pin). #314 now re-proposes the broken versions — it even rewrites the root override back to 1.3.1 — and since patch updates automerge, only its failing Vercel check prevents re-breakage.

## What

Two `packageRules` excluding exactly `@radix-ui/react-slot@1.3.1` and `radix-ui@1.6.5` via `allowedVersions`. Future Radix releases still flow through Renovate normally, so a fixed release will show up as a PR automatically.

## Cleanup trigger

When a fixed `react-slot` (> 1.3.1) ships: remove both rules and the `@radix-ui/react-slot` entry from the root `package.json` `overrides`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)