### PR TITLE
feat(web): masterclass demo polish — era 3 and era 4

### DIFF
--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/beats.test.ts
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/beats.test.ts
@@ -28,6 +28,14 @@ describe("BEATS", () => {
     expect(BEATS.integration.map((b) => b.id)).toEqual(["tab", "editor"]);
   });
 
+  test("era IV holds the ambient demo back until the second beat", () => {
+    // `masterclass.tsx` gates on these exact ids. A rename here without one
+    // there hides a demo for the whole talk and nothing else would catch it.
+    expect(BEATS.outlook.map((b) => b.id)).toEqual(["compiled", "ambient"]);
+    expect(reached("outlook", "ambient", "compiled", true)).toBe(false);
+    expect(reached("outlook", "ambient", "ambient", true)).toBe(true);
+  });
+
   test("steps without beats are ungated", () => {
     expect(BEATS.completion).toEqual([]);
     expect(reached("completion", "anything", "anything", true)).toBe(true);

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/beats.ts
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/beats.ts
@@ -32,7 +32,10 @@ export const BEATS: Record<StepId, readonly Beat[]> = {
     { id: "editor", label: "the chat moves in" },
   ],
   intro: [],
-  outlook: [],
+  outlook: [
+    { id: "compiled", label: "compiled on the spot" },
+    { id: "ambient", label: "ambient context" },
+  ],
   synthesis: [],
 };
 

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-harness/diff-data.ts
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-harness/diff-data.ts
@@ -40,8 +40,8 @@ export const INITIAL_DIFFS: readonly DiffItem[] = [
   },
   {
     id: "iframe",
-    label: "stripe iframe — excepted (judgment call)",
-    log: "iframe left as-is — not worth pixel-chasing",
+    label: "social embed — excepted (judgment call)",
+    log: "social embed left as-is — not worth pixel-chasing",
     status: "excepted",
   },
 ] as const;

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-harness/index.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-harness/index.tsx
@@ -31,14 +31,19 @@ export function Era3Harness() {
 
   return (
     <div className="rounded-xl border border-foreground/10 p-4 sm:p-6">
+      <p className="font-medium text-base">Pixel for pixel</p>
+      <p className="mt-1 mb-4 max-w-2xl text-muted-foreground text-sm">
+        A client&apos;s site on the left, its rebuild on the right, and the
+        auditor the agent wrote to hold one against the other.
+      </p>
+
       {/* target vs candidate */}
       <div className="grid gap-4 sm:grid-cols-2">
-        <Mock label="Target · WordPress" tight={false} />
+        <Mock isTarget label="Target · WordPress" resolved={resolved} />
         <Mock
           converged={isClear(state)}
           label="Candidate · Next.js"
-          // candidate tightens toward target as diffs resolve
-          tight={resolved("padding")}
+          resolved={resolved}
         />
       </div>
 
@@ -82,7 +87,7 @@ export function Era3Harness() {
               {remainingCount(state)}
             </span>
           </div>
-          <div className="mt-3 flex gap-2">
+          <div className="mt-3">
             <button
               className="rounded bg-[#21262d] px-3 py-1 text-[#c9d1d9] disabled:opacity-40"
               disabled={state.running || isClear(state)}
@@ -91,48 +96,53 @@ export function Era3Harness() {
             >
               Run audit
             </button>
-            <button
-              className="rounded border border-[#30363d] px-3 py-1"
-              onClick={() => dispatch({ type: "reset" })}
-              type="button"
-            >
-              Reset
-            </button>
-            <button
-              className={cn(
-                "rounded px-3 py-1",
-                state.validated
-                  ? "bg-[#238636] text-white"
-                  : "border border-[#30363d] text-[#8b949e]"
-              )}
-              disabled={!isClear(state)}
-              onClick={() => dispatch({ type: "validate" })}
-              type="button"
-            >
-              {state.validated ? "VALIDATED ✓" : "Validate"}
-            </button>
           </div>
         </div>
       </div>
 
+      {/* Outside the terminal, in the page's own idiom and right-aligned —
+          the same control Era II's demos use, so one gesture means one thing
+          across the talk. */}
+      <div className="mt-4 flex">
+        <button
+          className="ml-auto shrink-0 rounded border border-foreground/15 px-2 py-1 font-mono text-muted-foreground text-xs hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+          disabled={state.running}
+          onClick={() => dispatch({ type: "reset" })}
+          type="button"
+        >
+          ↺ reset
+        </button>
+      </div>
+
       <p className="mt-4 text-foreground/55 text-sm italic">
         You wrote the validation rules. The agent screenshots, diffs, fixes, and
-        re-runs — on its own — until the count hits zero. The iframe stays
+        re-runs — on its own — until the count hits zero. The embed stays
         flagged: knowing what isn&apos;t worth it is your judgment too.
       </p>
     </div>
   );
 }
 
+/**
+ * Every row in the diff list owns a property of this skeleton, so resolving a
+ * row visibly moves the candidate toward the target instead of only striking
+ * text off a list. The target renders as if everything were already fixed —
+ * it is the thing being matched — so a clean run makes the two panels
+ * identical except for the excepted embed, which is the judgment call.
+ */
 function Mock({
   label,
-  tight,
   converged,
+  isTarget,
+  resolved,
 }: {
-  label: string;
-  tight: boolean;
   converged?: boolean;
+  isTarget?: boolean;
+  label: string;
+  resolved: (id: string) => boolean;
 }) {
+  const fixed = (id: string) => isTarget || resolved(id);
+
   return (
     <div>
       <div className="mb-1 font-mono text-[10px] text-muted-foreground uppercase tracking-wide">
@@ -142,13 +152,33 @@ function Mock({
       <div className="rounded-lg border border-foreground/10 bg-background p-4">
         <div
           className={cn(
-            "h-2.5 w-3/5 rounded bg-foreground motion-safe:transition-all",
-            tight ? "mb-2" : "mb-3"
+            "rounded motion-safe:transition-all motion-safe:duration-500",
+            fixed("padding") ? "mb-3" : "mb-6",
+            fixed("weight") ? "h-2.5" : "h-3",
+            fixed("width") ? "w-3/5" : "w-[52%]",
+            fixed("color") ? "bg-foreground/75" : "bg-foreground"
           )}
         />
         <div className="mb-1.5 h-1.5 w-11/12 rounded bg-foreground/30" />
         <div className="mb-3 h-1.5 w-4/5 rounded bg-foreground/30" />
-        <div className="h-6 w-28 rounded bg-emerald-500" />
+        <div
+          className={cn(
+            "h-6 rounded bg-emerald-500 motion-safe:transition-all motion-safe:duration-500",
+            fixed("button") ? "w-28" : "w-32"
+          )}
+        />
+        {/* The exception, kept visible: clearing the count never makes this
+            one match, and it is not supposed to. */}
+        <div
+          className={cn(
+            "mt-3 flex h-8 items-center justify-center rounded border border-dashed font-mono text-[9px] uppercase tracking-wide",
+            isTarget
+              ? "border-foreground/20 bg-foreground/[0.03] text-muted-foreground"
+              : "border-amber-500/60 bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400"
+          )}
+        >
+          {isTarget ? "social embed" : "⚠ social embed"}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-harness/reducer.test.ts
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-harness/reducer.test.ts
@@ -11,9 +11,8 @@ function run(state = initialHarnessState()) {
 }
 
 describe("era3 harness reducer", () => {
-  test("starts with pending diffs and the iframe excepted, not validated", () => {
+  test("starts with pending diffs and the embed excepted", () => {
     const s = initialHarnessState();
-    expect(s.validated).toBe(false);
     expect(s.diffs.some((d) => d.status === "excepted")).toBe(true);
     expect(remainingCount(s)).toBeGreaterThan(0);
   });
@@ -40,16 +39,14 @@ describe("era3 harness reducer", () => {
     expect(s.running).toBe(false);
   });
 
-  test("validate only succeeds when clear", () => {
-    const notClear = run();
-    expect(harnessReducer(notClear, { type: "validate" }).validated).toBe(
-      false
-    );
+  test("the excepted diff is never resolved by ticking", () => {
     let s = run();
     while (remainingCount(s) > 0) {
       s = harnessReducer(s, { type: "tick" });
     }
-    expect(harnessReducer(s, { type: "validate" }).validated).toBe(true);
+    // The skeleton keeps its amber marker after a clean run, which is the
+    // demo's point: clear does not mean identical.
+    expect(s.diffs.filter((d) => d.status === "excepted")).toHaveLength(1);
   });
 
   test("reset returns to the initial state", () => {
@@ -57,6 +54,7 @@ describe("era3 harness reducer", () => {
     s = harnessReducer(s, { type: "tick" });
     const r = harnessReducer(s, { type: "reset" });
     expect(remainingCount(r)).toBe(remainingCount(initialHarnessState()));
-    expect(r.validated).toBe(false);
+    expect(r.log).toEqual([]);
+    expect(r.running).toBe(false);
   });
 });

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-harness/reducer.ts
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-harness/reducer.ts
@@ -7,13 +7,11 @@ export interface HarnessState {
   diffs: DiffItem[];
   log: string[];
   running: boolean;
-  validated: boolean;
 }
 
 export type HarnessAction =
   | { type: "run" }
   | { type: "tick" }
-  | { type: "validate" }
   | { type: "reset" };
 
 export function initialHarnessState(): HarnessState {
@@ -21,7 +19,6 @@ export function initialHarnessState(): HarnessState {
     diffs: INITIAL_DIFFS.map((d) => ({ ...d })),
     log: [],
     running: false,
-    validated: false,
   };
 }
 
@@ -61,8 +58,6 @@ export function harnessReducer(
         running: stillPending,
       };
     }
-    case "validate":
-      return { ...state, validated: isClear(state) };
     case "reset":
       return initialHarnessState();
     default:

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-ladder/index.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-ladder/index.tsx
@@ -13,75 +13,113 @@ const RUNNER_TESTS = [
 ] as const;
 const RUNNER_MS = 450;
 
+/** The bar is relative to the worst year, so 2024 reads as full. */
+const MAX_LINES = Math.max(...LADDER_STAGES.map((s) => s.lines));
+
+function diffTone(line: string): string {
+  if (line.startsWith("+")) {
+    return "text-emerald-700 dark:text-emerald-400";
+  }
+  if (line.startsWith("-")) {
+    return "text-red-700 dark:text-red-400";
+  }
+  return "text-muted-foreground";
+}
+
 export function Era3Ladder() {
   const [year, setYear] = useState<LadderStage["year"]>("2024");
   const stage = LADDER_STAGES.find((s) => s.year === year) ?? LADDER_STAGES[0];
 
   return (
     <div className="mt-10 rounded-xl border border-foreground/10 p-4 sm:p-6">
-      <p className="font-medium text-sm">What I read, year by year</p>
+      <p className="font-medium text-base">What I read, year by year</p>
       <p className="mt-1 max-w-2xl text-muted-foreground text-sm">
         The same feature you fixed by hand earlier, reviewed three years
         running.
       </p>
 
-      <div className="mt-4 flex gap-2">
-        {LADDER_STAGES.map((s) => (
-          <button
-            className={cn(
-              "rounded-full border px-3 py-1 font-mono text-xs",
-              s.year === year
-                ? "border-ht-cyan-500 text-foreground"
-                : "border-foreground/15 text-muted-foreground hover:text-foreground"
-            )}
-            key={s.year}
-            onClick={() => setYear(s.year)}
-            type="button"
-          >
-            {s.year} · {s.read}
-          </button>
-        ))}
-      </div>
+      {/* One object, not three controls and a detached result. The tabs are
+          the deck's existing folder grammar: the live year carries the panel's
+          own fill and runs to the band's bottom edge, so it merges into the
+          artifact beneath it rather than floating above it. */}
+      <div className="mt-4 overflow-hidden rounded-lg border border-foreground/10">
+        <div className="flex h-10 items-stretch gap-1 bg-foreground/[0.04] dark:bg-black/30">
+          {LADDER_STAGES.map((s) => (
+            <button
+              aria-pressed={s.year === year}
+              className={cn(
+                "rounded-t-md px-4 font-mono text-xs transition-colors sm:text-sm",
+                s.year === year
+                  ? "bg-muted/40 text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
+              key={s.year}
+              onClick={() => setYear(s.year)}
+              type="button"
+            >
+              {s.year}
+            </button>
+          ))}
+        </div>
 
-      <div className="mt-4 rounded-lg border border-foreground/10 bg-muted/40 p-4">
-        {stage.artifact === "diff" && (
-          <div className="max-h-44 overflow-y-auto font-mono text-xs leading-5">
-            {stage.body.map((l, i) => (
-              <div
-                className={
-                  l.startsWith("+")
-                    ? "text-emerald-700 dark:text-emerald-400"
-                    : l.startsWith("-")
-                      ? "text-red-700 dark:text-red-400"
-                      : "text-muted-foreground"
-                }
-                key={`${i}-${l}`}
-              >
-                {l}
-              </div>
-            ))}
-          </div>
-        )}
-        {stage.artifact === "plan" && (
-          <ol className="list-decimal space-y-1 pl-5 font-mono text-xs leading-6">
-            {stage.body.map((l) => (
-              <li key={l}>{l.replace(/^\d+\.\s*/, "")}</li>
-            ))}
-          </ol>
-        )}
-        {stage.artifact === "design" && (
-          <div className="grid gap-4 sm:grid-cols-2">
-            <p className="font-mono text-xs leading-6">
-              {stage.body.join(" ")}
+        <div className="bg-muted/40">
+          <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 px-4 pt-4">
+            <p className="font-medium text-sm">{stage.read}</p>
+            <p className="font-mono text-[11px] text-muted-foreground tabular-nums">
+              {stage.approx ? "~" : ""}
+              {stage.lines} lines read
             </p>
-            <TestRunner key={year} />
           </div>
-        )}
-      </div>
 
-      <p className="mt-3 max-w-2xl text-foreground/55 text-sm italic">
-        {stage.line}
-      </p>
+          {/* The argument, as a measurement: what a human has to read collapses
+              from a wall of diff to three sentences. */}
+          <div className="mt-3 px-4">
+            <div className="h-1 w-full overflow-hidden rounded-full bg-foreground/10">
+              <div
+                className="h-full min-w-[3px] rounded-full bg-ht-cyan-500 transition-[width] duration-500"
+                style={{ width: `${(stage.lines / MAX_LINES) * 100}%` }}
+              />
+            </div>
+          </div>
+
+          <div className="px-4 py-4">
+            {/* `whitespace-pre` below is load-bearing: these are divs, so
+                without it HTML collapses the diff's leading indentation and
+                every nested line lands flush against the +. */}
+            {stage.artifact === "diff" && (
+              <div className="max-h-44 overflow-auto font-mono text-xs leading-5">
+                {stage.body.map((l, i) => (
+                  <div
+                    className={cn("whitespace-pre", diffTone(l))}
+                    key={`${i}-${l}`}
+                  >
+                    {l}
+                  </div>
+                ))}
+              </div>
+            )}
+            {stage.artifact === "plan" && (
+              <ol className="list-decimal space-y-1 pl-5 font-mono text-xs leading-6">
+                {stage.body.map((l) => (
+                  <li key={l}>{l.replace(/^\d+\.\s*/, "")}</li>
+                ))}
+              </ol>
+            )}
+            {stage.artifact === "design" && (
+              <div className="grid gap-4 sm:grid-cols-2">
+                <p className="font-mono text-xs leading-6">
+                  {stage.body.join(" ")}
+                </p>
+                <TestRunner key={year} />
+              </div>
+            )}
+          </div>
+
+          <p className="border-foreground/10 border-t px-4 py-3 text-foreground/55 text-sm italic">
+            {stage.line}
+          </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-ladder/stages.ts
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-ladder/stages.ts
@@ -1,8 +1,17 @@
 export interface LadderStage {
+  /** Renders the count as an estimate rather than a tally. */
+  approx?: boolean;
   artifact: "diff" | "plan" | "design";
   /** the artifact's rendered lines (mono) */
   body: readonly string[];
   line: string;
+  /**
+   * Lines of text this year's artifact asks a human to read. The diff counts
+   * every changed line, not just the ones shown; the plan counts the detail
+   * under each step, not the five headlines it lists. Same unit all three
+   * years, so the bar comparing them is honest.
+   */
+  lines: number;
   read: string;
   year: "2024" | "2025" | "2026";
 }
@@ -41,10 +50,13 @@ export const LADDER_STAGES: readonly LadderStage[] = [
       "  // …214 more lines",
     ],
     line: "Plan mode, then a wall of diffs. I read every generated line like a literature student. I have a literature degree. I did not expect to use it on diffs.",
-    read: "I read the code.",
+    // 27 lines shown, 214 more behind the fold.
+    lines: 241,
+    read: "I checked every line.",
     year: "2024",
   },
   {
+    approx: true,
     artifact: "plan",
     body: [
       "1. Extract validation into validateDiscount(code)",
@@ -54,7 +66,10 @@ export const LADDER_STAGES: readonly LadderStage[] = [
       "5. Migrate call sites; delete the naked DISCOUNTS lookup",
     ],
     line: "The design was mine; Claude wrote the implementation plan. I reviewed intentions, not artifacts.",
-    read: "I read the plan.",
+    // Not the five headlines below — everything written under them, which was
+    // still about half a diff's worth of reading.
+    lines: 120,
+    read: "I reviewed the plan.",
     year: "2025",
   },
   {
@@ -65,6 +80,7 @@ export const LADDER_STAGES: readonly LadderStage[] = [
       "the proof.",
     ],
     line: "I plan the design. Claude writes the implementation plan. TDD runs the execution — tests read the code, I don't.",
+    lines: 3,
     read: "I read the design. Tests read the code.",
     year: "2026",
   },

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-loop/index.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-loop/index.tsx
@@ -61,7 +61,7 @@ export function Era3Loop() {
 
   return (
     <div className="mb-10 rounded-xl border border-foreground/10 p-4 sm:p-6">
-      <p className="font-medium text-sm">
+      <p className="font-medium text-base">
         An LLM with tools, trapped in a loop
       </p>
       <p className="mt-1 max-w-2xl text-muted-foreground text-sm">

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-meter/index.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-meter/index.tsx
@@ -90,7 +90,7 @@ function TimelineRow({
 export function Era3Meter() {
   return (
     <div className="mt-10 rounded-xl border border-foreground/10 p-4 sm:p-6">
-      <p className="font-medium text-sm">The meter</p>
+      <p className="font-medium text-base">What it costs to work this way</p>
       <p className="mt-1 max-w-2xl text-muted-foreground text-sm">
         Working like this has an economy. Five-hour windows that start at your
         first message; a weekly quota; a flat price for what would otherwise be

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-meter/index.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-meter/index.tsx
@@ -48,7 +48,7 @@ const KPIS: readonly { label: string; value: string }[] = [
     label: "My monthly usage at API prices",
     value: "thousands of €",
   },
-  { label: "The subscription, flat", value: "€180 · ×2" },
+  { label: "The subscription, flat", value: "€180" },
   {
     label: "Weekly quota — resets Saturday 11:00",
     value: "gone by Wednesday",
@@ -123,7 +123,7 @@ export function Era3Meter() {
         </div>
       </div>
 
-      <FieldNote className="mt-6" date="2026-07">
+      <FieldNote className="mt-6" label="how I work">
         I say hi to the agent at seven sharp. Not to be polite — the five-hour
         meter starts when I do. Start coding at ten, and the next window opens
         just as the first would bite. The greeting is load-bearing.

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-pipeline/index.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-pipeline/index.tsx
@@ -5,8 +5,8 @@ import { useEffect, useReducer } from "react";
 import { LANES, type LaneMeta } from "./lanes";
 import {
   attentionTarget,
-  boardReducer,
   type BoardState,
+  boardReducer,
   initialBoardState,
   isBoardDone,
   isSettled,
@@ -18,11 +18,11 @@ const PHASES = ["plan", "execute", "validate"] as const;
 type Column = (typeof PHASES)[number];
 
 const PHASE_COLUMN: Record<LanePhase, Column> = {
-  plan: "plan",
-  execute: "execute",
-  validate: "validate",
   "awaiting-signature": "validate",
   done: "validate",
+  execute: "execute",
+  plan: "plan",
+  validate: "validate",
 };
 
 export function Era3Pipeline() {
@@ -52,7 +52,7 @@ export function Era3Pipeline() {
 
   return (
     <div className="mt-10 rounded-xl border border-foreground/10 p-4 sm:p-6">
-      <p className="font-medium text-sm">Three lanes, one week</p>
+      <p className="font-medium text-base">Three lanes, one week</p>
       <p className="mt-1 max-w-2xl text-muted-foreground text-sm">
         Three real streams from my board. Every lane runs plan → execute →
         validate. The board runs itself — click where it asks you.

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-pipeline/index.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-pipeline/index.tsx
@@ -4,26 +4,17 @@ import { cn } from "@repo/design-system/lib/utils";
 import { useEffect, useReducer } from "react";
 import { LANES, type LaneMeta } from "./lanes";
 import {
-  attentionTarget,
-  type BoardState,
+  type BoardAction,
   boardReducer,
+  formatElapsed,
+  inFlightCount,
   initialBoardState,
+  isAnyExecuting,
   isBoardDone,
-  isSettled,
-  type LanePhase,
+  type LaneState,
 } from "./reducer";
 
-const TICK_MS = 700;
-const PHASES = ["plan", "execute", "validate"] as const;
-type Column = (typeof PHASES)[number];
-
-const PHASE_COLUMN: Record<LanePhase, Column> = {
-  "awaiting-signature": "validate",
-  done: "validate",
-  execute: "execute",
-  plan: "plan",
-  validate: "validate",
-};
+const TICK_MS = 1000;
 
 export function Era3Pipeline() {
   const [state, dispatch] = useReducer(
@@ -32,30 +23,31 @@ export function Era3Pipeline() {
     initialBoardState
   );
 
+  // Only on the clock while something is actually running.
+  const running = isAnyExecuting(state);
   useEffect(() => {
-    if (isSettled(state)) {
+    if (!running) {
       return;
     }
-    const reduce = window.matchMedia(
-      "(prefers-reduced-motion: reduce)"
-    ).matches;
-    if (reduce) {
-      dispatch({ type: "fastForward" });
-      return;
-    }
-    const id = setInterval(() => dispatch({ type: "tick" }), TICK_MS);
+    const id = setInterval(
+      () => dispatch({ ms: TICK_MS, type: "tick" }),
+      TICK_MS
+    );
     return () => clearInterval(id);
-  }, [state]);
+  }, [running]);
 
-  const target = attentionTarget(state);
   const done = isBoardDone(state);
+  const inFlight = inFlightCount(state);
 
   return (
     <div className="mt-10 rounded-xl border border-foreground/10 p-4 sm:p-6">
-      <p className="font-medium text-base">Three lanes, one week</p>
+      <p className="font-medium text-base">
+        Three features, one thread of attention
+      </p>
       <p className="mt-1 max-w-2xl text-muted-foreground text-sm">
-        Three real streams from my board. Every lane runs plan → execute →
-        validate. The board runs itself — click where it asks you.
+        Three real features from my board. Nothing moves to the next step unless
+        I move it, so I hold all three at once — and that is the tiring part.
+        The agent could take a fourth. I couldn&apos;t.
       </p>
 
       <div className="mt-5 space-y-4">
@@ -64,25 +56,29 @@ export function Era3Pipeline() {
             dispatch={dispatch}
             key={lane.id}
             lane={lane}
-            state={state}
-            target={target}
+            laneState={state.lanes[lane.id]}
           />
         ))}
       </div>
 
-      <div className="mt-4 flex items-center justify-between gap-4">
+      <div className="mt-4 flex items-start justify-between gap-4">
         <p className="max-w-2xl text-foreground/55 text-sm italic">
           {done
-            ? "Notice where your clicks went. That's where the job went."
-            : "Only one column ever needs you."}
+            ? "Twelve decisions across three features. None of them was hard. Holding all three at once was."
+            : "Hand one off, then the next. The work happens at the same time. My attention can't."}
         </p>
-        <button
-          className="shrink-0 rounded border border-foreground/15 px-3 py-1 text-muted-foreground text-xs hover:text-foreground"
-          onClick={() => dispatch({ type: "reset" })}
-          type="button"
-        >
-          Reset
-        </button>
+        <div className="flex shrink-0 items-center gap-3">
+          <span className="font-mono text-[10px] text-muted-foreground tabular-nums">
+            {inFlight} in my head
+          </span>
+          <button
+            className="shrink-0 rounded border border-foreground/15 px-2 py-1 font-mono text-muted-foreground text-xs hover:text-foreground"
+            onClick={() => dispatch({ type: "reset" })}
+            type="button"
+          >
+            ↺ reset
+          </button>
+        </div>
       </div>
     </div>
   );
@@ -91,17 +87,12 @@ export function Era3Pipeline() {
 function LaneRow({
   dispatch,
   lane,
-  state,
-  target,
+  laneState,
 }: {
-  dispatch: React.Dispatch<Parameters<typeof boardReducer>[1]>;
+  dispatch: React.Dispatch<BoardAction>;
   lane: LaneMeta;
-  state: BoardState;
-  target: ReturnType<typeof attentionTarget>;
+  laneState: LaneState;
 }) {
-  const laneState = state.lanes[lane.id];
-  const activeColumn = PHASE_COLUMN[laneState.phase];
-
   return (
     <div className="rounded-lg border border-foreground/10 p-3">
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
@@ -114,94 +105,139 @@ function LaneRow({
         {lane.tense}
       </p>
       <div className="mt-2 grid grid-cols-3 gap-2">
-        {PHASES.map((column) => (
-          <PhaseCell
-            column={column}
-            dispatch={dispatch}
-            key={column}
-            lane={lane}
-            laneState={laneState}
-            reached={PHASES.indexOf(column) <= PHASES.indexOf(activeColumn)}
-            target={target}
-          />
-        ))}
+        <PlanCell
+          dispatch={dispatch}
+          laneId={lane.id}
+          phase={laneState.phase}
+        />
+        <ExecuteCell
+          dispatch={dispatch}
+          laneId={lane.id}
+          laneState={laneState}
+        />
+        <ValidateCell
+          dispatch={dispatch}
+          laneId={lane.id}
+          phase={laneState.phase}
+        />
       </div>
     </div>
   );
 }
 
-function PhaseCell({
-  column,
-  dispatch,
-  lane,
-  laneState,
-  reached,
-  target,
-}: {
-  column: Column;
-  dispatch: React.Dispatch<Parameters<typeof boardReducer>[1]>;
-  lane: LaneMeta;
-  laneState: { phase: LanePhase };
-  reached: boolean;
-  target: ReturnType<typeof attentionTarget>;
-}) {
-  const isActive = PHASE_COLUMN[laneState.phase] === column;
-  const isDone = laneState.phase === "done" ? reached : reached && !isActive;
-  const isRagGate =
-    lane.id === "rag" && column === "plan" && laneState.phase === "plan";
-  const isDepsGate =
-    lane.id === "deps" &&
-    column === "validate" &&
-    laneState.phase === "awaiting-signature";
-  const isTargeted =
-    (isRagGate && target === "rag-plan") ||
-    (isDepsGate && target === "deps-signature");
+const CELL =
+  "rounded-md border px-2 py-2 text-center font-mono text-[11px] transition-colors";
+const CELL_WAITING = "border-foreground/5 text-muted-foreground/40 opacity-50";
+const CELL_SPENT = "border-foreground/10 text-muted-foreground";
+const ACTION =
+  "w-full rounded bg-foreground px-2 py-1 text-background transition-opacity hover:opacity-90";
 
-  return (
-    <div
-      className={cn(
-        "rounded-md border px-2 py-2 text-center font-mono text-[11px]",
-        isDone && "border-foreground/10 text-muted-foreground",
-        isActive &&
-          laneState.phase !== "done" &&
-          !isRagGate &&
-          !isDepsGate &&
-          "animate-pulse border-ht-cyan-500/50 text-foreground",
-        !reached && "border-foreground/5 text-muted-foreground/40 opacity-50",
-        isTargeted && "ring-2 ring-ht-cyan-500"
-      )}
-    >
-      {isRagGate ? (
+function PlanCell({
+  dispatch,
+  laneId,
+  phase,
+}: {
+  dispatch: React.Dispatch<BoardAction>;
+  laneId: LaneMeta["id"];
+  phase: LaneState["phase"];
+}) {
+  if (phase === "planned") {
+    return (
+      <div className={cn(CELL, "border-ht-cyan-500/50")}>
         <button
-          className="w-full rounded bg-foreground px-2 py-1 text-background"
-          onClick={() => dispatch({ type: "handOff" })}
+          className={ACTION}
+          onClick={() => dispatch({ lane: laneId, type: "handOff" })}
           type="button"
         >
           Hand off →
         </button>
-      ) : isDepsGate ? (
+      </div>
+    );
+  }
+  return <div className={cn(CELL, CELL_SPENT)}>✓ plan</div>;
+}
+
+function ExecuteCell({
+  dispatch,
+  laneId,
+  laneState,
+}: {
+  dispatch: React.Dispatch<BoardAction>;
+  laneId: LaneMeta["id"];
+  laneState: LaneState;
+}) {
+  const { elapsedMs, phase } = laneState;
+  if (phase === "planned") {
+    return <div className={cn(CELL, CELL_WAITING)}>execute</div>;
+  }
+  // Stopping the clock is its own click: the agent finishing is not the same
+  // event as deciding the result is worth validating.
+  if (phase === "executing") {
+    return (
+      <div className={cn(CELL, "space-y-1.5 border-ht-cyan-500/50")}>
+        <div className="text-foreground tabular-nums">
+          ⏱ {formatElapsed(elapsedMs)}
+        </div>
         <button
-          className="w-full rounded bg-foreground px-2 py-1 text-background"
-          onClick={() => dispatch({ type: "approveMerge" })}
+          className={ACTION}
+          onClick={() => dispatch({ lane: laneId, type: "markDone" })}
           type="button"
         >
-          Approve merge ✓
+          done
         </button>
-      ) : lane.id === "wp" &&
-        column === "validate" &&
-        laneState.phase === "done" ? (
+      </div>
+    );
+  }
+  return (
+    <div className={cn(CELL, CELL_SPENT)}>
+      <span className="tabular-nums">✓ {formatElapsed(elapsedMs)}</span>
+    </div>
+  );
+}
+
+function ValidateCell({
+  dispatch,
+  laneId,
+  phase,
+}: {
+  dispatch: React.Dispatch<BoardAction>;
+  laneId: LaneMeta["id"];
+  phase: LaneState["phase"];
+}) {
+  if (phase === "executed") {
+    return (
+      <div className={cn(CELL, "border-ht-cyan-500/50")}>
+        <button
+          className={ACTION}
+          onClick={() => dispatch({ lane: laneId, type: "toValidation" })}
+          type="button"
+        >
+          Validate →
+        </button>
+      </div>
+    );
+  }
+  if (phase === "validating") {
+    return (
+      <div className={cn(CELL, "border-ht-cyan-500/50")}>
+        <button
+          className={ACTION}
+          onClick={() => dispatch({ lane: laneId, type: "accept" })}
+          type="button"
+        >
+          Accept ✓
+        </button>
+      </div>
+    );
+  }
+  if (phase === "validated") {
+    return (
+      <div className={cn(CELL, "border-foreground/10")}>
         <span className="rounded bg-[#238636] px-2 py-0.5 text-white">
           VALIDATED ✓
         </span>
-      ) : (
-        <span>
-          {isDone ? "✓ " : ""}
-          {column}
-          {lane.id === "deps" && column === "validate" && isDone
-            ? " · merged"
-            : ""}
-        </span>
-      )}
-    </div>
-  );
+      </div>
+    );
+  }
+  return <div className={cn(CELL, CELL_WAITING)}>validate</div>;
 }

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-pipeline/reducer.test.ts
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-pipeline/reducer.test.ts
@@ -1,100 +1,122 @@
 import { describe, expect, test } from "bun:test";
 import {
-  attentionTarget,
   type BoardState,
   boardReducer,
-  EXECUTE_TICKS,
+  EXECUTION_CAP_MS,
+  formatElapsed,
+  inFlightCount,
   initialBoardState,
+  isAnyExecuting,
   isBoardDone,
-  isSettled,
-  VALIDATE_TICKS,
+  type LaneId,
 } from "./reducer";
 
-const tick = (s: BoardState, n = 1) => {
-  let next = s;
-  for (let i = 0; i < n; i += 1) {
-    next = boardReducer(next, { type: "tick" });
-  }
-  return next;
-};
-const AUTO_TICKS = EXECUTE_TICKS + VALIDATE_TICKS;
+function tick(state: BoardState, ms: number): BoardState {
+  return boardReducer(state, { ms, type: "tick" });
+}
 
-describe("initial board", () => {
-  test("rag plans, wp and deps are already executing", () => {
+function handOff(state: BoardState, lane: LaneId): BoardState {
+  return boardReducer(state, { lane, type: "handOff" });
+}
+
+describe("era3 board", () => {
+  test("every lane starts planned, so each one needs its own hand-off", () => {
     const s = initialBoardState();
-    expect(s.lanes.rag.phase).toBe("plan");
-    expect(s.lanes.wp.phase).toBe("execute");
-    expect(s.lanes.deps.phase).toBe("execute");
+    expect(Object.values(s.lanes).every((l) => l.phase === "planned")).toBe(
+      true
+    );
+    expect(isAnyExecuting(s)).toBe(false);
   });
 
-  test("attention starts at the rag plan gate", () => {
-    expect(attentionTarget(initialBoardState())).toBe("rag-plan");
-  });
-});
-
-describe("automatic lanes", () => {
-  test("wp reaches done without any click", () => {
-    const s = tick(initialBoardState(), AUTO_TICKS);
-    expect(s.lanes.wp.phase).toBe("done");
+  test("a lane never advances on its own — only clicks move it", () => {
+    let s = handOff(initialBoardState(), "rag");
+    for (let i = 0; i < 60; i += 1) {
+      s = tick(s, 1000);
+    }
+    expect(s.lanes.rag.phase).toBe("executing");
   });
 
-  test("deps parks at awaiting-signature and never auto-merges", () => {
-    const s = tick(initialBoardState(), AUTO_TICKS + 20);
-    expect(s.lanes.deps.phase).toBe("awaiting-signature");
+  test("the clock runs only for lanes that were handed off", () => {
+    const s = tick(handOff(initialBoardState(), "rag"), 3000);
+    expect(s.lanes.rag.elapsedMs).toBe(3000);
+    expect(s.lanes.wp.elapsedMs).toBe(0);
+    expect(s.lanes.deps.elapsedMs).toBe(0);
   });
 
-  test("rag never leaves plan without the hand-off click", () => {
-    const s = tick(initialBoardState(), 50);
-    expect(s.lanes.rag.phase).toBe("plan");
-  });
-});
-
-describe("gates", () => {
-  test("handOff moves rag into execute, then ticks carry it to done", () => {
-    let s = boardReducer(initialBoardState(), { type: "handOff" });
-    expect(s.lanes.rag.phase).toBe("execute");
-    s = tick(s, AUTO_TICKS);
-    expect(s.lanes.rag.phase).toBe("done");
+  test("lanes run in parallel, each on its own clock", () => {
+    let s = handOff(initialBoardState(), "rag");
+    s = tick(s, 2000);
+    s = handOff(s, "wp");
+    s = tick(s, 2000);
+    expect(s.lanes.rag.elapsedMs).toBe(4000);
+    expect(s.lanes.wp.elapsedMs).toBe(2000);
+    expect(inFlightCount(s)).toBe(2);
   });
 
-  test("approveMerge is a no-op until deps awaits a signature", () => {
-    const early = boardReducer(initialBoardState(), { type: "approveMerge" });
-    expect(early.lanes.deps.phase).toBe("execute");
-    const parked = tick(initialBoardState(), AUTO_TICKS);
-    const merged = boardReducer(parked, { type: "approveMerge" });
-    expect(merged.lanes.deps.phase).toBe("done");
-  });
-});
-
-describe("attention + completion", () => {
-  test("attention moves to the deps signature once rag is handed off", () => {
-    let s = boardReducer(initialBoardState(), { type: "handOff" });
-    s = tick(s, AUTO_TICKS);
-    expect(attentionTarget(s)).toBe("deps-signature");
+  test("done stops the clock without moving the work to validation", () => {
+    let s = tick(handOff(initialBoardState(), "rag"), 5000);
+    s = boardReducer(s, { lane: "rag", type: "markDone" });
+    expect(s.lanes.rag.phase).toBe("executed");
+    s = tick(s, 9000);
+    expect(s.lanes.rag.elapsedMs).toBe(5000);
+    // Still mine to carry: stopped is not accepted.
+    expect(inFlightCount(s)).toBe(1);
   });
 
-  test("board completes only after both clicks and all ticks", () => {
-    let s = boardReducer(initialBoardState(), { type: "handOff" });
-    s = tick(s, AUTO_TICKS);
-    expect(isBoardDone(s)).toBe(false);
-    s = boardReducer(s, { type: "approveMerge" });
+  test("validation cannot be reached while the clock is still running", () => {
+    const running = tick(handOff(initialBoardState(), "rag"), 2000);
+    expect(boardReducer(running, { lane: "rag", type: "toValidation" })).toBe(
+      running
+    );
+  });
+
+  test("the clock stops at the hidden cap, and the lane keeps waiting", () => {
+    let s = handOff(initialBoardState(), "rag");
+    s = tick(s, EXECUTION_CAP_MS + 60_000);
+    expect(s.lanes.rag.elapsedMs).toBe(EXECUTION_CAP_MS);
+    expect(s.lanes.rag.phase).toBe("executing");
+  });
+
+  test("transitions are refused out of order", () => {
+    const s = initialBoardState();
+    expect(boardReducer(s, { lane: "rag", type: "toValidation" })).toBe(s);
+    expect(boardReducer(s, { lane: "rag", type: "accept" })).toBe(s);
+    const executing = handOff(s, "rag");
+    expect(boardReducer(executing, { lane: "rag", type: "accept" })).toBe(
+      executing
+    );
+  });
+
+  test("a second hand-off does not restart a running lane", () => {
+    const running = tick(handOff(initialBoardState(), "rag"), 4000);
+    expect(handOff(running, "rag")).toBe(running);
+  });
+
+  test("the board is done only once all three are accepted", () => {
+    let s = initialBoardState();
+    for (const lane of ["rag", "wp", "deps"] as LaneId[]) {
+      // Four clicks a lane: hand off, done, validate, accept.
+      s = handOff(s, lane);
+      s = boardReducer(s, { lane, type: "markDone" });
+      s = boardReducer(s, { lane, type: "toValidation" });
+      expect(isBoardDone(s)).toBe(false);
+      s = boardReducer(s, { lane, type: "accept" });
+    }
     expect(isBoardDone(s)).toBe(true);
-    expect(attentionTarget(s)).toBe(null);
-  });
-});
-
-describe("fastForward and reset", () => {
-  test("fastForward settles the board but holds every gate", () => {
-    const s = boardReducer(initialBoardState(), { type: "fastForward" });
-    expect(isSettled(s)).toBe(true);
-    expect(s.lanes.rag.phase).toBe("plan");
-    expect(s.lanes.wp.phase).toBe("done");
-    expect(s.lanes.deps.phase).toBe("awaiting-signature");
+    expect(inFlightCount(s)).toBe(0);
   });
 
   test("reset returns to the initial state", () => {
-    let s = boardReducer(initialBoardState(), { type: "fastForward" });
-    s = boardReducer(s, { type: "reset" });
-    expect(s).toEqual(initialBoardState());
+    const s = tick(handOff(initialBoardState(), "rag"), 8000);
+    expect(boardReducer(s, { type: "reset" })).toEqual(initialBoardState());
+  });
+});
+
+describe("formatElapsed", () => {
+  test("pads seconds and rolls into minutes", () => {
+    expect(formatElapsed(0)).toBe("0:00");
+    expect(formatElapsed(7000)).toBe("0:07");
+    expect(formatElapsed(65_000)).toBe("1:05");
+    expect(formatElapsed(EXECUTION_CAP_MS)).toBe("5:00");
   });
 });

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-pipeline/reducer.ts
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-pipeline/reducer.ts
@@ -1,99 +1,96 @@
 export type LaneId = "rag" | "wp" | "deps";
 
+/**
+ * A lane never moves on its own. Every transition is a click, because the
+ * point of the board is where the human's attention goes: you hand work off,
+ * you decide when it comes back, and the agent owns everything in between.
+ */
 export type LanePhase =
-  | "plan"
-  | "execute"
-  | "validate"
-  | "awaiting-signature"
-  | "done";
+  | "planned"
+  | "executing"
+  | "executed"
+  | "validating"
+  | "validated";
 
 export interface LaneState {
+  /** Frozen the moment the lane leaves `executing`. */
+  elapsedMs: number;
   phase: LanePhase;
-  ticksInPhase: number;
 }
 
 export interface BoardState {
   lanes: Record<LaneId, LaneState>;
 }
 
+/**
+ * `markDone` only stops the clock; `toValidation` only moves the work. They
+ * are separate because they are separate judgments: the agent finishing is not
+ * the same event as me deciding the result is worth validating.
+ */
 export type BoardAction =
-  | { type: "tick" }
-  | { type: "handOff" }
-  | { type: "approveMerge" }
-  | { type: "fastForward" }
+  | { type: "handOff"; lane: LaneId }
+  | { type: "markDone"; lane: LaneId }
+  | { type: "toValidation"; lane: LaneId }
+  | { type: "accept"; lane: LaneId }
+  | { type: "tick"; ms: number }
   | { type: "reset" };
 
-export const EXECUTE_TICKS = 4;
-export const VALIDATE_TICKS = 2;
+/**
+ * A run that nobody stops would otherwise count into the hours while the talk
+ * moves on. The cap is deliberately not shown: the lane stays executing, the
+ * clock just stops being interesting.
+ */
+export const EXECUTION_CAP_MS = 5 * 60 * 1000;
 
 const LANE_IDS: readonly LaneId[] = ["rag", "wp", "deps"];
 
 export function initialBoardState(): BoardState {
   return {
     lanes: {
-      deps: { phase: "execute", ticksInPhase: 0 },
-      rag: { phase: "plan", ticksInPhase: 0 },
-      wp: { phase: "execute", ticksInPhase: 0 },
+      deps: { elapsedMs: 0, phase: "planned" },
+      rag: { elapsedMs: 0, phase: "planned" },
+      wp: { elapsedMs: 0, phase: "planned" },
     },
   };
 }
 
-function tickLane(id: LaneId, lane: LaneState): LaneState {
-  if (
-    lane.phase === "plan" ||
-    lane.phase === "awaiting-signature" ||
-    lane.phase === "done"
-  ) {
-    return lane;
-  }
-  const ticks = lane.ticksInPhase + 1;
-  if (lane.phase === "execute") {
-    return ticks >= EXECUTE_TICKS
-      ? { phase: "validate", ticksInPhase: 0 }
-      : { phase: "execute", ticksInPhase: ticks };
-  }
-  // validate
-  if (ticks >= VALIDATE_TICKS) {
-    return id === "deps"
-      ? { phase: "awaiting-signature", ticksInPhase: 0 }
-      : { phase: "done", ticksInPhase: 0 };
-  }
-  return { phase: "validate", ticksInPhase: ticks };
-}
-
-function tickBoard(state: BoardState): BoardState {
-  return {
-    lanes: {
-      deps: tickLane("deps", state.lanes.deps),
-      rag: tickLane("rag", state.lanes.rag),
-      wp: tickLane("wp", state.lanes.wp),
-    },
-  };
-}
-
-export function isSettled(state: BoardState): boolean {
-  return LANE_IDS.every((id) => {
-    const { phase } = state.lanes[id];
-    return (
-      phase === "plan" || phase === "awaiting-signature" || phase === "done"
-    );
-  });
+/** Whether anything is on the clock, so the UI can idle its interval. */
+export function isAnyExecuting(state: BoardState): boolean {
+  return LANE_IDS.some((id) => state.lanes[id].phase === "executing");
 }
 
 export function isBoardDone(state: BoardState): boolean {
-  return LANE_IDS.every((id) => state.lanes[id].phase === "done");
+  return LANE_IDS.every((id) => state.lanes[id].phase === "validated");
 }
 
-export function attentionTarget(
-  state: BoardState
-): "rag-plan" | "deps-signature" | null {
-  if (state.lanes.rag.phase === "plan") {
-    return "rag-plan";
+/** Lanes handed off but not yet accepted — what I am still carrying. */
+export function inFlightCount(state: BoardState): number {
+  return LANE_IDS.filter((id) => {
+    const { phase } = state.lanes[id];
+    return phase !== "planned" && phase !== "validated";
+  }).length;
+}
+
+export function formatElapsed(ms: number): string {
+  const total = Math.floor(ms / 1000);
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+function advance(
+  state: BoardState,
+  id: LaneId,
+  from: LanePhase,
+  to: LanePhase
+): BoardState {
+  const lane = state.lanes[id];
+  if (lane.phase !== from) {
+    return state;
   }
-  if (state.lanes.deps.phase === "awaiting-signature") {
-    return "deps-signature";
-  }
-  return null;
+  return {
+    lanes: { ...state.lanes, [id]: { ...lane, phase: to } },
+  };
 }
 
 export function boardReducer(
@@ -101,34 +98,29 @@ export function boardReducer(
   action: BoardAction
 ): BoardState {
   switch (action.type) {
-    case "tick":
-      return tickBoard(state);
     case "handOff":
-      if (state.lanes.rag.phase !== "plan") {
+      return advance(state, action.lane, "planned", "executing");
+    case "markDone":
+      return advance(state, action.lane, "executing", "executed");
+    case "toValidation":
+      return advance(state, action.lane, "executed", "validating");
+    case "accept":
+      return advance(state, action.lane, "validating", "validated");
+    case "tick": {
+      if (!isAnyExecuting(state)) {
         return state;
       }
-      return {
-        lanes: {
-          ...state.lanes,
-          rag: { phase: "execute", ticksInPhase: 0 },
-        },
-      };
-    case "approveMerge":
-      if (state.lanes.deps.phase !== "awaiting-signature") {
-        return state;
+      const lanes = { ...state.lanes };
+      for (const id of LANE_IDS) {
+        const lane = lanes[id];
+        if (lane.phase === "executing") {
+          lanes[id] = {
+            ...lane,
+            elapsedMs: Math.min(lane.elapsedMs + action.ms, EXECUTION_CAP_MS),
+          };
+        }
       }
-      return {
-        lanes: {
-          ...state.lanes,
-          deps: { phase: "done", ticksInPhase: 0 },
-        },
-      };
-    case "fastForward": {
-      let next = state;
-      while (!isSettled(next)) {
-        next = tickBoard(next);
-      }
-      return next;
+      return { lanes };
     }
     case "reset":
       return initialBoardState();

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-reach/index.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era3-reach/index.tsx
@@ -68,7 +68,7 @@ export function Era3Reach({ revealed, fenced }: Era3ReachProps) {
 
   return (
     <div className="mt-10 rounded-xl border border-foreground/10 p-4 sm:p-6">
-      <p className="font-medium text-sm">Nothing was outside the loop</p>
+      <p className="font-medium text-base">Nothing was outside the loop</p>
       <p className="mt-1 max-w-2xl text-muted-foreground text-sm">
         One instruction, on a repo where nothing was fenced off.
       </p>

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era4-runtime/company-brain.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era4-runtime/company-brain.tsx
@@ -1,60 +1,196 @@
 "use client";
 
-import { motion } from "motion/react";
+import { useEffect, useState } from "react";
 
-const SOURCES = ["Email", "Slack", "Meet transcripts", "Docs", "Tickets"];
+/** The channels a company already talks in, top to bottom. */
+const CHANNELS = ["Email", "Slack", "Meet transcripts", "Docs", "Tickets"];
+
+/** One rail per channel. The rails converge on a single junction: five inputs,
+ *  one document — the collapse is the whole point of the figure. */
+const RAIL_Y = [34, 76, 118, 160, 202];
+const JUNCTION_X = 302;
+const JUNCTION_Y = 118;
+
+const railPath = (y: number) =>
+  `M144,${y} C214,${y} 244,${JUNCTION_Y} ${JUNCTION_X},${JUNCTION_Y}`;
+
+/** The rails stop being drawn at the junction, but a packet keeps going: past
+ *  it there is one shared wire, and the dot has to be seen entering the file
+ *  for the write below to read as its consequence. */
+const packetPath = (y: number) => `${railPath(y)} H366`;
+
+/** Deliberately unequal, and prime-ish against each other, so arrivals never
+ *  settle into a march. Ambient means you stop noticing the rhythm. */
+const PACKET_SEC = [2.6, 3.1, 2.2, 3.4, 2.8];
+
+/** What lands in the document, with the channel it came from. */
+const WRITES = [
+  "+ decision recorded · slack",
+  "+ owner assigned · meet",
+  "+ question opened · email",
+  "+ thread linked · tickets",
+];
+
+const WRITE_MS = 2600;
 
 export function CompanyBrain() {
-  const reduce =
-    typeof window !== "undefined" &&
-    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  // Read after mount, never during render: the server has no matchMedia, and
+  // branching on it inline would render two different trees and fail hydration.
+  const [reduce, setReduce] = useState(false);
+  const [write, setWrite] = useState(0);
+
+  useEffect(() => {
+    setReduce(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+  }, []);
+
+  useEffect(() => {
+    if (reduce) {
+      return;
+    }
+    const id = setInterval(
+      () => setWrite((i) => (i + 1) % WRITES.length),
+      WRITE_MS
+    );
+    return () => clearInterval(id);
+  }, [reduce]);
 
   return (
     <div className="mt-10 rounded-xl border border-foreground/10 p-4 sm:p-6">
-      <p className="mb-1 font-medium text-sm">
-        The other half: ambient context
-      </p>
+      <p className="mb-1 font-medium text-sm">Ambient context</p>
       <p className="mb-6 max-w-2xl text-muted-foreground text-sm">
         Remember ferrying context by hand — paste it in, copy the answer back
         out? Here that dissolves: a company&apos;s communication flows into one
         living document the model already stands inside.
       </p>
-      <div className="grid items-center gap-4 sm:grid-cols-[1fr_auto_1fr]">
-        <ul className="space-y-2">
-          {SOURCES.map((s, i) => (
-            <motion.li
-              animate={
-                reduce
-                  ? { opacity: 1 }
-                  : { opacity: [0.4, 1, 0.4], x: [0, 8, 0] }
-              }
-              className="rounded-md border border-foreground/10 bg-muted/40 px-3 py-1.5 text-sm"
-              key={s}
-              transition={{
-                delay: i * 0.3,
-                duration: 2.4,
-                repeat: Number.POSITIVE_INFINITY,
-              }}
+
+      <svg
+        className="w-full"
+        role="img"
+        viewBox="0 0 560 236"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <title>
+          Email, Slack, meeting transcripts, documents and tickets flowing along
+          five converging rails into a single file, company-brain.md
+        </title>
+
+        {/* The rails, and the labels they leave from. */}
+        <g className="text-foreground/60" fill="currentColor">
+          {CHANNELS.map((channel, i) => (
+            <text
+              className="font-mono text-[11px]"
+              key={channel}
+              textAnchor="end"
+              x={136}
+              y={RAIL_Y[i] + 4}
             >
-              {s}
-            </motion.li>
+              {channel}
+            </text>
           ))}
-        </ul>
-        <div className="text-center font-mono text-muted-foreground text-xs">
-          → LLM →
-        </div>
-        <div className="rounded-lg border border-ht-cyan-500/40 bg-ht-cyan-50/60 p-4 dark:bg-ht-cyan-950/30">
-          <div className="font-mono text-muted-foreground text-xs">
+        </g>
+        <g
+          className="text-foreground/15"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1}
+        >
+          {CHANNELS.map((channel, i) => (
+            <path d={railPath(RAIL_Y[i])} key={channel} />
+          ))}
+        </g>
+
+        {/* Past the junction there is only one line. */}
+        <g className="text-ht-cyan-500">
+          <circle cx={JUNCTION_X} cy={JUNCTION_Y} fill="currentColor" r={3.5} />
+          <path
+            d={`M${JUNCTION_X},${JUNCTION_Y} H352`}
+            opacity={0.55}
+            stroke="currentColor"
+            strokeWidth={1.5}
+          />
+        </g>
+
+        {/* company-brain.md */}
+        <rect
+          className="text-ht-cyan-500/5"
+          fill="currentColor"
+          height={184}
+          rx={10}
+          width={196}
+          x={356}
+          y={26}
+        />
+        <rect
+          className="text-ht-cyan-500/40"
+          fill="none"
+          height={184}
+          rx={10}
+          stroke="currentColor"
+          width={196}
+          x={356}
+          y={26}
+        />
+        <g className="font-mono text-[10px]">
+          <text
+            className="text-foreground/50"
+            fill="currentColor"
+            x={372}
+            y={52}
+          >
             company-brain.md
-          </div>
-          <div className="mt-2 space-y-1 font-mono text-foreground/70 text-xs">
-            <div># Decisions</div>
-            <div># People &amp; ownership</div>
-            <div># Open questions</div>
-            <div className="text-muted-foreground">…silos collapsed</div>
-          </div>
-        </div>
-      </div>
+          </text>
+          <path
+            className="text-ht-cyan-500/25"
+            d="M372,62 H536"
+            stroke="currentColor"
+            strokeWidth={1}
+          />
+          <g className="text-foreground/70" fill="currentColor">
+            <text x={372} y={88}>
+              # Decisions
+            </text>
+            <text x={372} y={108}>
+              # People &amp; ownership
+            </text>
+            <text x={372} y={128}>
+              # Open questions
+            </text>
+          </g>
+          <text
+            className="text-ht-cyan-600 dark:text-ht-cyan-400"
+            fill="currentColor"
+            x={372}
+            y={158}
+          >
+            {WRITES[write]}
+          </text>
+        </g>
+        {/* Still being written. */}
+        <rect
+          className="text-ht-cyan-500 motion-safe:animate-pulse"
+          fill="currentColor"
+          height={11}
+          width={6}
+          x={372}
+          y={170}
+        />
+
+        {/* The packets. Each rides the exact path its rail draws, so a dot can
+            never drift off the line it is meant to be travelling. */}
+        {!reduce &&
+          CHANNELS.map((channel, i) => (
+            <g className="text-ht-cyan-500" key={channel}>
+              <circle cx={0} cy={0} fill="currentColor" opacity={0.2} r={6} />
+              <circle cx={0} cy={0} fill="currentColor" r={2.5} />
+              <animateMotion
+                begin={`${i * 0.55}s`}
+                dur={`${PACKET_SEC[i]}s`}
+                path={packetPath(RAIL_Y[i])}
+                repeatCount="indefinite"
+              />
+            </g>
+          ))}
+      </svg>
     </div>
   );
 }

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era4-runtime/index.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/demos/era4-runtime/index.tsx
@@ -1,14 +1,20 @@
 "use client";
 
+import { cn } from "@repo/design-system/lib/utils";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { CompanyBrain } from "./company-brain";
+import { Expandable } from "../../../../components/expandable";
 import { DashboardRenderer } from "./dashboard-renderer";
 import { generateDashboard } from "./generate-dashboard";
 import { INTENTS } from "./match";
-import type { RenderSpec } from "./render-spec";
+import type { RenderSpec, Widget } from "./render-spec";
 
 type View = "idle" | "compiling" | "rendered";
 const CHAR_MS = 6;
+
+/** Every widget kind `render-spec.ts` allows — the whole vocabulary the model
+ *  writes in. Shown so the room can see the answer is a choice from a fixed
+ *  catalog, not free-form UI. */
+const WIDGET_KINDS: Widget["kind"][] = ["kpi", "bar", "line", "table"];
 
 export function Era4Runtime() {
   const [question, setQuestion] = useState(
@@ -58,6 +64,8 @@ export function Era4Runtime() {
     []
   );
 
+  const usedKinds = new Set(spec?.widgets.map((w) => w.kind));
+
   return (
     <>
       <div className="rounded-xl border border-foreground/10 p-4 sm:p-6">
@@ -97,32 +105,97 @@ export function Era4Runtime() {
           ))}
         </div>
 
-        {view === "compiling" && (
-          <pre className="mt-5 max-h-64 overflow-auto rounded-lg border border-foreground/10 bg-muted/40 p-4 font-mono text-xs">
-            {specText}
-            <span className="animate-pulse">▋</span>
-          </pre>
+        {/* The grammar, always on screen: the model picks from these four and
+            may not invent a fifth. Kinds the current spec used are lit. */}
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <span className="font-mono text-[11px] text-muted-foreground">
+            catalog
+          </span>
+          {WIDGET_KINDS.map((kind) => (
+            <span
+              className={cn(
+                "rounded border px-2 py-0.5 font-mono text-[11px]",
+                usedKinds.has(kind)
+                  ? "border-ht-cyan-500/40 bg-ht-cyan-500/10 text-foreground"
+                  : "border-foreground/10 text-muted-foreground/60"
+              )}
+              key={kind}
+            >
+              {kind}
+            </span>
+          ))}
+          <span className="text-muted-foreground/60 text-xs">
+            — the model may only use these four
+          </span>
+        </div>
+
+        {spec === null ? null : (
+          <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,3fr)]">
+            {/* Column stretches to the rendered pane beside it: a short code
+                block next to a tall dashboard reads as an afterthought, and
+                wrapping beats a horizontal scrollbar nobody will drag on a
+                projector. */}
+            <div className="flex flex-col">
+              <p className="mb-2 font-mono text-[11px] text-muted-foreground">
+                the model emits
+              </p>
+              <pre className="min-h-80 flex-1 overflow-auto whitespace-pre-wrap break-words rounded-lg border border-foreground/10 bg-muted/40 p-4 font-mono text-[11px] leading-5">
+                {specText}
+                {view === "compiling" && (
+                  <span className="animate-pulse">▋</span>
+                )}
+              </pre>
+            </div>
+            <div>
+              <p className="mb-2 font-mono text-[11px] text-muted-foreground">
+                the page compiles
+              </p>
+              <div className="min-h-80 rounded-lg border border-foreground/10 p-4">
+                {view === "rendered" ? (
+                  <div className="fade-in animate-in duration-300">
+                    <DashboardRenderer spec={spec} />
+                  </div>
+                ) : (
+                  <p className="font-mono text-[11px] text-muted-foreground">
+                    compiling…
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
         )}
 
-        {view === "rendered" && spec && (
-          <div className="fade-in mt-5 animate-in duration-300">
-            <DashboardRenderer spec={spec} />
-            <p className="mt-4 text-foreground/55 text-sm italic">
-              That interface didn&apos;t exist until you asked. Nothing here was
-              pre-built — the question compiled it, and the next question will
-              throw it away.
-            </p>
-          </div>
+        {view === "rendered" && (
+          <p className="mt-4 text-foreground/55 text-sm italic">
+            That interface didn&apos;t exist until you asked. Nothing here was
+            pre-built — the question compiled it, and the next question will
+            throw it away.
+          </p>
         )}
 
         {view === "idle" && (
           <p className="mt-5 text-muted-foreground text-sm">
-            Ask a question — there is no pre-built dashboard. The UI is compiled
-            from your question.
+            Ask a question — nothing here is pre-built; the UI is compiled from
+            what you asked. The numbers are real and cited: German labour-market
+            data, 2024–2026.
           </p>
         )}
       </div>
-      <CompanyBrain />
+      {/* Colocated with the dashboard it explains: the fold is about this
+          demo's mechanism, not the era's argument. */}
+      <Expandable label="Did you know? There's no component behind that dashboard.">
+        <p>
+          The dashboard is json-render underneath: the model emits a spec, the
+          page compiles it. No route, no component — the interface is a runtime
+          value, and the durable artifact is one file, the schema that says what
+          a spec may contain: four widget kinds and a source field. Notice what
+          that makes the job. You don&apos;t review the UI, you review the
+          grammar it has to be expressible in — and the rule above it, that if a
+          figure can&apos;t be cited, it doesn&apos;t ship. The same work as
+          writing the rules an agent&apos;s loop must satisfy, one surface
+          further out.
+        </p>
+      </Expandable>
     </>
   );
 }

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/field-note.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/field-note.tsx
@@ -3,7 +3,11 @@ import { cn } from "@repo/design-system/lib/utils";
 interface FieldNoteProps {
   children: React.ReactNode;
   className?: string;
-  date: string;
+  /**
+   * Omit when the aside describes a standing practice rather than something
+   * observed on a date — a date implies the claim could go stale.
+   */
+  date?: string;
   /**
    * Defaults to "field note", which claims the passage is Eric's own dated
    * observation. Override it when the aside carries something else.
@@ -30,8 +34,10 @@ export function FieldNote({
         className
       )}
     >
+      {/* One expression, not `{label} · {date}`: JSX would leave the separator
+          and its spaces behind when the date is absent. */}
       <p className="font-mono text-[11px] text-muted-foreground uppercase tracking-[0.2em]">
-        {label} · {date}
+        {date ? `${label} · ${date}` : label}
       </p>
       <div className="mt-2 font-mono text-foreground/70 text-sm/6">
         {children}

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/masterclass.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/masterclass.tsx
@@ -18,6 +18,7 @@ import { Era3Meter } from "./demos/era3-meter";
 import { Era3Pipeline } from "./demos/era3-pipeline";
 import { Era3Reach } from "./demos/era3-reach";
 import { Era4Runtime } from "./demos/era4-runtime";
+import { CompanyBrain } from "./demos/era4-runtime/company-brain";
 import { EraPanel } from "./era-panel";
 import { FieldNote } from "./field-note";
 import { Intro } from "./intro";
@@ -218,21 +219,16 @@ export function Masterclass() {
             )}
             {step === "outlook" && (
               <EraPanel
-                deepCut={
-                  <p>
-                    The dashboard you just watched assemble is json-render under
-                    the hood — a spec the model emits and the page compiles at
-                    runtime. The same engine lets an end user build their own UI
-                    without a developer in the loop. Code stops being a
-                    permanent artifact and becomes a byproduct of intent.
-                  </p>
-                }
-                expandLabel="Did you know? That dashboard didn't exist a second ago."
-                name="The runtime frontier"
-                reality="An honest label: this isn't lived experience yet — nobody works here daily. It's the model crossing out of the build phase into the running software itself: ask a question, and the interface is compiled on the spot. Try it on the questions that matter — the data behind it is real, German, and cited."
-                years="2026 →"
+                name="The model moves in"
+                reality="The model moved into the running product: ask, and the interface is built on the spot. It moved into everything a company writes: mail, chat, meeting notes, tickets. Neither is a demo. Both change who gets to ask."
+                years="now"
               >
-                <Era4Runtime />
+                <BeatSlot show={has("compiled")}>
+                  <Era4Runtime />
+                </BeatSlot>
+                <BeatSlot show={has("ambient")}>
+                  <CompanyBrain />
+                </BeatSlot>
               </EraPanel>
             )}
             {step === "synthesis" && <Synthesis />}

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/masterclass.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/masterclass.tsx
@@ -176,16 +176,6 @@ export function Masterclass() {
             )}
             {step === "agentic-engineering" && (
               <EraPanel
-                deepCut={
-                  <p>
-                    I didn&apos;t build the harness myself. The agent built its
-                    own auditor; I set the rules it audits against. A page that
-                    used to take hours of manual diffing came in at 2–3 hours of
-                    the agent working a list I never had to touch — about a week
-                    of work I didn&apos;t do.
-                  </p>
-                }
-                expandLabel="Did you know? I didn't build the harness either."
                 name="Agentic engineering"
                 reality="Strip the debate away: an agent is an LLM with tools, trapped in a loop. Claude Code put that loop in a terminal — barely useful at first, even on the strongest coding models. Then the loop learned to run longer; minutes became hours. You stop writing syntax and start writing the rules the loop must satisfy."
                 years="2024 → now"

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/steps.test.ts
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/steps.test.ts
@@ -19,7 +19,7 @@ describe("masterclass steps", () => {
       "skepticism",
       "guarded fascination",
       "the trust pivot",
-      "the next frontier",
+      "recognition",
     ]);
   });
 

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/steps.ts
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/steps.ts
@@ -21,7 +21,7 @@ export const STEPS: readonly Step[] = [
     label: "2024 → now",
     vibe: "the trust pivot",
   },
-  { id: "outlook", label: "2026 →", vibe: "the next frontier" },
+  { id: "outlook", label: "meanwhile", vibe: "recognition" },
   { id: "synthesis", label: "Synthesis" },
 ] as const;
 

--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/synthesis.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/synthesis.tsx
@@ -5,39 +5,28 @@ export function Synthesis() {
     <section className="fade-in animate-in py-10 duration-300 sm:py-16">
       <Subheading>Where this leaves you</Subheading>
       <Heading as="h2" className="mt-3 text-4xl sm:text-5xl">
-        The model changed. You didn&apos;t.
+        The machine didn&apos;t change. The job did.
       </Heading>
       <div className="mt-8 max-w-2xl space-y-5 text-foreground/75 text-lg leading-8">
         <p>
-          Seven years, three machines. One that could only continue, taught to
-          answer. An answerer in a browser tab, moved into the editor. A model
-          with tools, trapped in a loop — until the loop could carry real work.
-          Every step was shaped by what the model could barely do, and by how
-          people learned to use it.
+          Seven years, one machine. It could only continue your sentence, until
+          people taught it what an answer looks like. It moved into the editor.
+          It picked up tools and a loop that runs for hours. Now it&apos;s
+          moving into the products themselves. Underneath every one of those: a
+          pattern, continued until it looks finished.
         </p>
         <p>
-          Through all of it, the thing that made the work <em>yours</em> was
-          never the syntax. It was the judgment: what to ask, what to trust,
-          where to draw the boundary, what counts as done.
+          You saw it stop that way twice, seven years apart — the base model
+          that answered a question with a question, and the agent that typed{" "}
+          <em>done</em>
+          {" while the job wasn't."}
         </p>
-        <div className="rounded-xl border border-foreground/10 p-5">
-          <p className="text-base text-foreground/75">
-            One more thing. The page you&apos;re standing in was built by the
-            process it describes: a design spec I wrote, an implementation plan
-            Claude wrote, and tests that read the code so nobody had to. The
-            documents are real, and dated:
-          </p>
-          <ul className="mt-4 space-y-1 font-mono text-muted-foreground text-xs">
-            <li>
-              docs/superpowers/specs/2026-06-29-masterclass-four-eras-design.md
-            </li>
-            <li>docs/superpowers/plans/2026-06-29-masterclass-four-eras.md</li>
-            <li>apps/web/…/masterclass-28-07-2026/demos/**/*.test.ts</li>
-          </ul>
-          <p className="mt-4 text-foreground/55 text-sm italic">
-            The exhibit is its own final exhibit.
-          </p>
-        </div>
+        <p>
+          What moved is your side. You stopped writing syntax and started
+          writing what the work has to satisfy: the design, the plan, the tests
+          that read the code so you don&apos;t. Those hold only from outside the
+          loop. Inside it, a rule is a request.
+        </p>
         <p className="font-display text-2xl text-foreground italic">
           AI produces the artifact. You hold the meaning.
         </p>


### PR DESCRIPTION
Three commits polishing the masterclass demos ahead of the talk. No new routes, no dependency changes — `apps/web/app/[locale]/learn/masterclass-28-07-2026/` only.

## Era 4 + synthesis (`7db8f28`)

Era 4 was framed as a frontier — *"this isn't lived experience yet, nobody works here daily"* — while its own two demos show things that ship today. It is now present tense, and the synthesis follows: the talk spends four eras proving the machine barely changed, so *"The model changed. You didn't."* argued against its own evidence.

- Panel is **"The model moves in"**; the tab reads **`meanwhile · recognition`** — a parallel track, not a later period.
- Synthesis inverts to **"The machine didn't change. The job did."**, paying off Era 1's setup with the reach demo's rhyme: the agent that typed *done* because the pattern looked finished, exactly how the 2019 machine stopped.
- json-render now shows the spec **beside** the rendered dashboard instead of replacing it, under a catalog strip (`kpi/bar/line/table`) that lights the kinds the current spec used — the constraint made visible rather than asserted.
- Ambient context rebuilt as one SVG: five hairline rails converging on a junction, packets riding the exact path their rail draws and continuing into `company-brain.md`.
- Fixes a latent hydration bug — the old component called `matchMedia` **during render**, so server and client rendered different trees.

## Era 3 demos (`e5c656e`)

- **Reading ladder:** three pills and a detached result become one object with folder tabs, plus a reading-load bar making the argument a measurement — 241 lines of diff → ~120 → 3. Tense fixed: *"I read the code"* reads as present, so past years use verbs that can't be misread and `read` survives only in 2026.
- **Parity harness:** every diff row now owns a property of the skeleton, so resolving one visibly pulls the candidate toward the target. Fixes a real mismatch where a "matching" run left the two panels visibly different. Validate button removed entirely — button, action, and state field.
- Headlines on all six demos, at a size that leads their own subtitles.

## The board (`d0b7e01`)

Rebuilt around attention rather than throughput. It used to advance on a timer, which argued that the machine works and you approve. Now every transition is a click — four per feature — and `done` (stop the clock) is separate from `Validate →` (move the work), because the agent finishing is not the same event as deciding the result is worth validating.

**"Three features, one thread of attention."** The counter reads `n in my head`, and a stopped clock still counts.

## Verification

Every demo was driven in a browser, not just typechecked: the audit run watched converge, the ladder walked across all three years, the board fanned out to three concurrent clocks and back to zero, presenter mode gated beat-by-beat.

- 143 tests pass (12 new for the board's state machine, plus a test pinning the Era 4 beat ids, which are matched by string across two files).
- `tsc --noEmit` clean; Biome clean on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)