### PR TITLE
fix(web): drop the fold signpost from the masterclass intro

### DIFF
--- a/apps/web/app/[locale]/learn/masterclass-28-07-2026/intro.tsx
+++ b/apps/web/app/[locale]/learn/masterclass-28-07-2026/intro.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button } from "@repo/design-system/components/ui/button";
-import { MetaAside } from "../../components/meta-aside";
 import { Heading, Subheading } from "../../components/text";
 import { RhythmFigure } from "./rhythm-figure";
 
@@ -82,10 +81,6 @@ export function Intro({ onBegin }: { onBegin: () => void }) {
           </li>
         ))}
       </ul>
-
-      <MetaAside className="mt-6 max-w-2xl">
-        Engineers: the folds marked ▸ are for you.
-      </MetaAside>
 
       <Button className="mt-10" onClick={onBegin} size="lg" type="button">
         Begin →


### PR DESCRIPTION
The intro told engineers *"the folds marked ▸ are for you"*, which reads as a convention running through the talk. It no longer is: Era III's fold was removed and Era IV's moved inside its demo, leaving two.

- `masterclass.tsx` — *"Did you know? You were the bus."* (Era II)
- `era4-runtime/index.tsx` — *"Did you know? There's no component behind that dashboard."*

Promising a pattern and delivering it twice is worse than not promising it, and both remaining folds are self-evidently optional where they sit.

Five lines out of `intro.tsx`: the aside and its now-unused `MetaAside` import. The component is still used in eight other files, so nothing is orphaned.

143 tests pass; typecheck clean; Biome clean. Verified in the browser — the aside is gone from the rendered intro, which now runs from the three "before we start" points straight to **Begin →**, with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)