### PR TITLE
Landing page: one voice, written down, and applied

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,18 @@ Core infrastructure packages:
 - `turbo.json` - Turborepo task pipeline configuration
 - `biome.jsonc` - Linter/formatter configuration (extends ultracite presets)
 - `packages/database/types.ts` - Database document types
+- `docs/voice.md` - The writing voice for anything a visitor reads
 - Root `package.json` - Monorepo scripts, workspace configuration, and CLI entry point (`dist/index.js`)
+
+## Writing copy
+
+Any user-facing prose in `apps/web` or `packages/email` — exhibit titles, demo
+prose, asides, panel labels, FAQ answers, digest copy — follows `docs/voice.md`.
+Read it before drafting, and edit against its three passes (§5) before calling
+copy done. It is short on purpose; do not skim it.
+
+Do not add rules to it casually. A rejected line that an existing rule already
+predicted means the guide worked and needs no edit — see §9.
 
 ## Development Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,7 @@ Core infrastructure packages:
 - `biome.jsonc` - Linter/formatter configuration (extends ultracite presets)
 - `packages/database/types.ts` - Database document types
 - `docs/voice.md` - The writing voice for anything a visitor reads
+- `docs/design.md` - The instrument design grammar for the playground demos
 - Root `package.json` - Monorepo scripts, workspace configuration, and CLI entry point (`dist/index.js`)
 
 ## Writing copy
@@ -185,6 +186,19 @@ copy done. It is short on purpose; do not skim it.
 
 Do not add rules to it casually. A rejected line that an existing rule already
 predicted means the guide worked and needs no edit — see §9.
+
+## Designing demos
+
+Demo UI follows `docs/design.md` — the fixed instrument grammar (state gauge,
+view controls, specimen, deck, reference bar), the feedback rules, and the
+current migration state. Read it before building or reshaping an exhibit.
+Copy and demo co-evolve: when a panel gains a capability, re-run voice.md's
+three passes over the exhibit's prose, because the instrument may have
+obsoleted lines that were accurate when they shipped.
+
+Design rounds in this repo run on proposals: present options with a clear
+recommendation and the trade-offs named, get an explicit yes, then build.
+Project knowledge belongs in the repo — these docs, not external notes.
 
 ## Development Notes
 

--- a/apps/web/app/[locale]/(playground)/bake-swatch.tsx
+++ b/apps/web/app/[locale]/(playground)/bake-swatch.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@repo/design-system/lib/utils";
+
+interface BakeSwatchProps {
+  className?: string;
+  /** The six-hex-char bake fingerprint — a CSS color by construction. */
+  id: string;
+}
+
+/**
+ * The color the fingerprint spells. A bake id is six hex characters, which
+ * is to say a CSS color, so the swatch renders the literal value — nothing
+ * derived, nothing truncated. It is deliberately unlabeled: the hex beside
+ * it remains the information, this is the at-a-glance copy of it, and
+ * working out that the chip *is* the hash is left as a pleasure.
+ *
+ * `aria-hidden` because the channel is redundant by design — screen readers
+ * and colorblind visitors lose nothing but the glance.
+ */
+export function BakeSwatch({ className, id }: BakeSwatchProps) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        // The hairline border keeps a near-white bake visible on the panel
+        // background; `em` sizing scales the chip with its context, from the
+        // stamp headline down to a readout line.
+        "inline-block size-[0.55em] rounded-[0.12em] border border-foreground/20",
+        className
+      )}
+      style={{ backgroundColor: `#${id}` }}
+    />
+  );
+}

--- a/apps/web/app/[locale]/(playground)/boundary/client-card.tsx
+++ b/apps/web/app/[locale]/(playground)/boundary/client-card.tsx
@@ -18,7 +18,7 @@ export function ClientCard() {
     <BoundaryCard
       facts={[
         "can use state, effects, onClick",
-        "ships JavaScript (that's the deal)",
+        "ships JavaScript (that’s the deal)",
         "cannot read secrets — it lives in your tab",
       ]}
       side="client"

--- a/apps/web/app/[locale]/(playground)/boundary/server-card.tsx
+++ b/apps/web/app/[locale]/(playground)/boundary/server-card.tsx
@@ -44,7 +44,7 @@ export async function ServerCard() {
         </p>
         <p className="text-foreground/75 text-sm/6">
           at {formatStamp(new Date(facts.renderedAt))}, then cached. Refresh the
-          page — this card doesn&apos;t re-render, it gets re-served.
+          page — this card doesn&rsquo;t re-render, it gets re-served.
         </p>
       </div>
     </BoundaryCard>

--- a/apps/web/app/[locale]/(playground)/boundary/source.ts
+++ b/apps/web/app/[locale]/(playground)/boundary/source.ts
@@ -34,3 +34,13 @@ export function ClientCard() {
   );
 }
 `;
+
+/**
+ * The two cards joined for the reference bar's single drawer, each under its
+ * filename the way the shell demo joins bake.ts and actions.ts.
+ */
+export const BOUNDARY_SOURCE = `// server-card.tsx
+${SERVER_CARD_SOURCE.trim()}
+
+// client-card.tsx
+${CLIENT_CARD_SOURCE.trim()}`;

--- a/apps/web/app/[locale]/(playground)/code-block.tsx
+++ b/apps/web/app/[locale]/(playground)/code-block.tsx
@@ -15,7 +15,12 @@ async function highlight(
     transformers: [
       {
         pre(node) {
-          node.properties.title = title;
+          // An empty title means the chrome already names the file (the bar
+          // variant's summary) — skip the in-block heading entirely, since
+          // `.shiki[title]:before` would render it a second time.
+          if (title) {
+            node.properties.title = title;
+          }
         },
       },
     ],
@@ -27,6 +32,12 @@ interface CodeBlockProps {
   /** Displayed filename, e.g. "server-card.tsx". */
   file: string;
   lang?: string;
+  /**
+   * `standalone` draws its own frame below a panel (the legacy shape, still
+   * used by unmigrated demos). `bar` is the chassis form: frameless, its
+   * summary is the left side of the instrument's reference bar.
+   */
+  variant?: "bar" | "standalone";
 }
 
 /**
@@ -34,25 +45,47 @@ interface CodeBlockProps {
  * string, same HTML) and collapsed behind a native `<details>`. Zero
  * JavaScript ships to the browser for this: disclosure is HTML's job.
  */
-export async function CodeBlock({ code, file, lang = "tsx" }: CodeBlockProps) {
-  const html = await highlight(code, lang, file);
+export async function CodeBlock({
+  code,
+  file,
+  lang = "tsx",
+  variant = "standalone",
+}: CodeBlockProps) {
+  const html = await highlight(code, lang, variant === "bar" ? "" : file);
+
+  const summary = (
+    <summary className="flex h-11 cursor-pointer select-none items-center gap-2.5 px-4 font-mono font-semibold text-[0.7rem] text-muted-foreground uppercase tracking-[0.2em] transition-colors hover:text-foreground sm:px-5 [&::-webkit-details-marker]:hidden">
+      <span
+        aria-hidden="true"
+        className="inline-block transition-transform duration-200 group-open:rotate-90 motion-reduce:transition-none"
+      >
+        &#9656;
+      </span>
+      {file}
+    </summary>
+  );
+
+  const source = (
+    <div
+      className="overflow-x-auto border-foreground/10 border-t p-4 text-sm [&_pre]:m-0 [&_pre]:bg-transparent"
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: Shiki output from our own source strings, not user input
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+
+  if (variant === "bar") {
+    return (
+      <details className="group">
+        {summary}
+        {source}
+      </details>
+    );
+  }
 
   return (
     <details className="group mt-4 overflow-hidden rounded-xl border border-foreground/10 bg-background">
-      <summary className="flex cursor-pointer select-none items-center gap-2.5 px-4 py-3 font-mono font-semibold text-[0.7rem] text-muted-foreground uppercase tracking-[0.2em] transition-colors hover:text-foreground [&::-webkit-details-marker]:hidden">
-        <span
-          aria-hidden="true"
-          className="inline-block transition-transform duration-200 group-open:rotate-90 motion-reduce:transition-none"
-        >
-          &#9656;
-        </span>
-        the code — {file}
-      </summary>
-      <div
-        className="overflow-x-auto border-foreground/10 border-t p-4 text-sm [&_pre]:m-0 [&_pre]:bg-transparent"
-        // biome-ignore lint/security/noDangerouslySetInnerHtml: Shiki output from our own source strings, not user input
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
+      {summary}
+      {source}
     </details>
   );
 }

--- a/apps/web/app/[locale]/(playground)/code-block.tsx
+++ b/apps/web/app/[locale]/(playground)/code-block.tsx
@@ -1,29 +1,13 @@
 import { cacheLife } from "next/cache";
 import { codeToHtml } from "shiki";
 
-async function highlight(
-  code: string,
-  lang: string,
-  title: string
-): Promise<string> {
+async function highlight(code: string, lang: string): Promise<string> {
   "use cache";
   cacheLife("max");
   return await codeToHtml(code.trim(), {
     defaultColor: false,
     lang,
     themes: { dark: "github-dark", light: "github-light" },
-    transformers: [
-      {
-        pre(node) {
-          // An empty title means the chrome already names the file (the bar
-          // variant's summary) — skip the in-block heading entirely, since
-          // `.shiki[title]:before` would render it a second time.
-          if (title) {
-            node.properties.title = title;
-          }
-        },
-      },
-    ],
   });
 }
 
@@ -32,60 +16,35 @@ interface CodeBlockProps {
   /** Displayed filename, e.g. "server-card.tsx". */
   file: string;
   lang?: string;
-  /**
-   * `standalone` draws its own frame below a panel (the legacy shape, still
-   * used by unmigrated demos). `bar` is the chassis form: frameless, its
-   * summary is the left side of the instrument's reference bar.
-   */
-  variant?: "bar" | "standalone";
 }
 
 /**
  * The code behind a demo, highlighted on the server (cached forever — same
  * string, same HTML) and collapsed behind a native `<details>`. Zero
  * JavaScript ships to the browser for this: disclosure is HTML's job.
+ *
+ * Frameless by design: it renders as the left side of an instrument's
+ * reference bar, inside a ReferenceBar, and the chassis provides the frame.
  */
-export async function CodeBlock({
-  code,
-  file,
-  lang = "tsx",
-  variant = "standalone",
-}: CodeBlockProps) {
-  const html = await highlight(code, lang, variant === "bar" ? "" : file);
-
-  const summary = (
-    <summary className="flex h-11 cursor-pointer select-none items-center gap-2.5 px-4 font-mono font-semibold text-[0.7rem] text-muted-foreground uppercase tracking-[0.2em] transition-colors hover:text-foreground sm:px-5 [&::-webkit-details-marker]:hidden">
-      <span
-        aria-hidden="true"
-        className="inline-block transition-transform duration-200 group-open:rotate-90 motion-reduce:transition-none"
-      >
-        &#9656;
-      </span>
-      {file}
-    </summary>
-  );
-
-  const source = (
-    <div
-      className="overflow-x-auto border-foreground/10 border-t p-4 text-sm [&_pre]:m-0 [&_pre]:bg-transparent"
-      // biome-ignore lint/security/noDangerouslySetInnerHtml: Shiki output from our own source strings, not user input
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
-  );
-
-  if (variant === "bar") {
-    return (
-      <details className="group">
-        {summary}
-        {source}
-      </details>
-    );
-  }
+export async function CodeBlock({ code, file, lang = "tsx" }: CodeBlockProps) {
+  const html = await highlight(code, lang);
 
   return (
-    <details className="group mt-4 overflow-hidden rounded-xl border border-foreground/10 bg-background">
-      {summary}
-      {source}
+    <details className="group">
+      <summary className="flex h-11 cursor-pointer select-none items-center gap-2.5 px-4 font-mono font-semibold text-[0.7rem] text-muted-foreground uppercase tracking-[0.2em] transition-colors hover:text-foreground sm:px-5 [&::-webkit-details-marker]:hidden">
+        <span
+          aria-hidden="true"
+          className="inline-block transition-transform duration-200 group-open:rotate-90 motion-reduce:transition-none"
+        >
+          &#9656;
+        </span>
+        {file}
+      </summary>
+      <div
+        className="overflow-x-auto border-foreground/10 border-t p-4 text-sm [&_pre]:m-0 [&_pre]:bg-transparent"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: Shiki output from our own source strings, not user input
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
     </details>
   );
 }

--- a/apps/web/app/[locale]/(playground)/demo-section.tsx
+++ b/apps/web/app/[locale]/(playground)/demo-section.tsx
@@ -8,12 +8,16 @@ interface DemoLink {
 }
 
 interface DemoSectionProps {
+  /**
+   * The sentence a developer has actually said about this feature, set as the
+   * exhibit's heading. Everything below it is the answer.
+   */
+  belief: string;
   /** Syllabus position, e.g. "01". The order is the curriculum. */
   chapter: string;
   children: React.ReactNode;
   /** Official documentation this demo is a lab bench for. */
   docs: DemoLink;
-  hook: string;
   id: string;
   intro: React.ReactNode;
   meta?: React.ReactNode;
@@ -44,15 +48,29 @@ function SectionLink({ href, label }: DemoLink) {
 }
 
 /**
- * Editorial wrapper for one exhibit: numbered rail on the left, prose and the
- * live panel on the right, docs and source links at the bottom. Numbers mean
- * something here — the sections build on each other like a syllabus.
+ * The rail every exhibit hangs off. Just the number: the eyebrow beside it
+ * already names the topic, and the margin is quieter for holding one thing.
+ */
+function SectionRail({ chapter }: { chapter: string }) {
+  return (
+    <div className="text-right lg:block">
+      <span className="font-mono text-4xl text-muted-foreground/40 tabular-nums leading-none tracking-tight lg:text-5xl">
+        {chapter}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Editorial wrapper for one exhibit. It opens with a belief and answers it
+ * with a running instrument — the same shape the weekly digest uses, so the
+ * page and the email teach in one voice.
  */
 export function DemoSection({
+  belief,
   chapter,
   children,
   docs,
-  hook,
   id,
   intro,
   meta,
@@ -66,20 +84,16 @@ export function DemoSection({
       id={id}
     >
       <Container>
-        <div className="grid gap-x-12 gap-y-6 lg:grid-cols-[7rem_minmax(0,1fr)]">
-          <div>
-            <span className="font-mono text-muted-foreground/60 text-sm tracking-[0.25em] lg:block lg:text-right">
-              {chapter}
-            </span>
-          </div>
-          <div>
+        <div className="grid gap-x-12 gap-y-8 lg:grid-cols-[7rem_minmax(0,1fr)]">
+          <SectionRail chapter={chapter} />
+          <div className="ht-reveal">
             <Subheading>{topic}</Subheading>
             <Heading
               as="h2"
-              className="mt-3 max-w-2xl text-balance text-3xl sm:text-4xl md:text-5xl"
+              className="mt-3 max-w-2xl text-balance text-3xl/[1.1] sm:text-4xl/[1.1] md:text-5xl/[1.05]"
               id={`${id}-heading`}
             >
-              {hook}
+              {belief}
             </Heading>
             <div className="mt-6 max-w-2xl space-y-4 text-foreground/75 text-lg leading-8">
               {intro}

--- a/apps/web/app/[locale]/(playground)/demo-section.tsx
+++ b/apps/web/app/[locale]/(playground)/demo-section.tsx
@@ -1,12 +1,6 @@
 import { Container } from "../components/container";
 import { MetaAside } from "../components/meta-aside";
 import { Heading, Subheading } from "../components/text";
-import { SectionLink } from "./section-link";
-
-interface DemoLink {
-  href: string;
-  label: string;
-}
 
 interface DemoSectionProps {
   /**
@@ -17,20 +11,11 @@ interface DemoSectionProps {
   /** Build-order position, e.g. "02" — carried in the eyebrow, not a numeral. */
   chapter: string;
   children: React.ReactNode;
-  /**
-   * Legacy reference links, rendered below the panel. Migrated exhibits omit
-   * both and carry their references inside the instrument's reference bar.
-   */
-  docs?: DemoLink;
   id: string;
   intro: React.ReactNode;
   meta?: React.ReactNode;
-  /** Path inside this repo, relative to repo root, for the GitHub source link. */
-  sourcePath?: string;
   topic: string;
 }
-
-const GITHUB_BASE = "https://github.com/hasToggle/hasToggle.dev/tree/main/";
 
 /**
  * Editorial wrapper for one exhibit. It opens with a belief and answers it
@@ -47,11 +32,9 @@ export function DemoSection({
   belief,
   chapter,
   children,
-  docs,
   id,
   intro,
   meta,
-  sourcePath,
   topic,
 }: DemoSectionProps) {
   return (
@@ -87,15 +70,6 @@ export function DemoSection({
               {intro}
             </div>
             <div className="mt-10 max-w-3xl">{children}</div>
-            {docs && sourcePath ? (
-              <div className="mt-6 flex flex-wrap items-center gap-x-8 gap-y-2">
-                <SectionLink href={docs.href} label={`docs: ${docs.label}`} />
-                <SectionLink
-                  href={`${GITHUB_BASE}${encodeURI(sourcePath)}`}
-                  label="source on GitHub"
-                />
-              </div>
-            ) : null}
             {meta ? (
               <MetaAside className="mt-8 max-w-2xl" variant="comment">
                 {meta}

--- a/apps/web/app/[locale]/(playground)/demo-section.tsx
+++ b/apps/web/app/[locale]/(playground)/demo-section.tsx
@@ -1,6 +1,7 @@
 import { Container } from "../components/container";
 import { MetaAside } from "../components/meta-aside";
 import { Heading, Subheading } from "../components/text";
+import { SectionLink } from "./section-link";
 
 interface DemoLink {
   href: string;
@@ -13,58 +14,34 @@ interface DemoSectionProps {
    * exhibit's heading. Everything below it is the answer.
    */
   belief: string;
-  /** Syllabus position, e.g. "01". The order is the curriculum. */
+  /** Build-order position, e.g. "02" — carried in the eyebrow, not a numeral. */
   chapter: string;
   children: React.ReactNode;
-  /** Official documentation this demo is a lab bench for. */
-  docs: DemoLink;
+  /**
+   * Legacy reference links, rendered below the panel. Migrated exhibits omit
+   * both and carry their references inside the instrument's reference bar.
+   */
+  docs?: DemoLink;
   id: string;
   intro: React.ReactNode;
   meta?: React.ReactNode;
   /** Path inside this repo, relative to repo root, for the GitHub source link. */
-  sourcePath: string;
+  sourcePath?: string;
   topic: string;
 }
 
 const GITHUB_BASE = "https://github.com/hasToggle/hasToggle.dev/tree/main/";
 
-function SectionLink({ href, label }: DemoLink) {
-  return (
-    <a
-      className="group inline-flex items-baseline gap-2 font-mono text-muted-foreground text-xs transition-colors hover:text-foreground"
-      href={href}
-      rel="noreferrer"
-      target="_blank"
-    >
-      <span
-        aria-hidden="true"
-        className="text-ht-cyan-700/70 transition-colors group-hover:text-ht-cyan-700 dark:text-ht-cyan-300/70 dark:group-hover:text-ht-cyan-300"
-      >
-        ↗
-      </span>
-      {label}
-    </a>
-  );
-}
-
-/**
- * The rail every exhibit hangs off. Just the number: the eyebrow beside it
- * already names the topic, and the margin is quieter for holding one thing.
- */
-function SectionRail({ chapter }: { chapter: string }) {
-  return (
-    <div className="text-right lg:block">
-      <span className="font-mono text-4xl text-muted-foreground/40 tabular-nums leading-none tracking-tight lg:text-5xl">
-        {chapter}
-      </span>
-    </div>
-  );
-}
-
 /**
  * Editorial wrapper for one exhibit. It opens with a belief and answers it
  * with a running instrument — the same shape the weekly digest uses, so the
  * page and the email teach in one voice.
+ *
+ * The build order rides in the eyebrow (`02 · caching & revalidation`), the
+ * way engineers read identifiers — the watermark chapter numeral read as
+ * course furniture and is retired. The empty rail column keeps the page on
+ * one left edge. The aside is set as a code comment, because that is what
+ * it is: a note an engineer left in this codebase.
  */
 export function DemoSection({
   belief,
@@ -85,9 +62,20 @@ export function DemoSection({
     >
       <Container>
         <div className="grid gap-x-12 gap-y-8 lg:grid-cols-[7rem_minmax(0,1fr)]">
-          <SectionRail chapter={chapter} />
+          <div aria-hidden="true" />
           <div className="ht-reveal">
-            <Subheading>{topic}</Subheading>
+            <Subheading>
+              <span className="text-muted-foreground/60 tabular-nums">
+                {chapter}
+              </span>
+              <span
+                aria-hidden="true"
+                className="px-2 text-muted-foreground/40"
+              >
+                ·
+              </span>
+              {topic}
+            </Subheading>
             <Heading
               as="h2"
               className="mt-3 max-w-2xl text-balance text-3xl/[1.1] sm:text-4xl/[1.1] md:text-5xl/[1.05]"
@@ -99,15 +87,19 @@ export function DemoSection({
               {intro}
             </div>
             <div className="mt-10 max-w-3xl">{children}</div>
-            <div className="mt-6 flex flex-wrap items-center gap-x-8 gap-y-2">
-              <SectionLink href={docs.href} label={`docs: ${docs.label}`} />
-              <SectionLink
-                href={`${GITHUB_BASE}${encodeURI(sourcePath)}`}
-                label="source on GitHub"
-              />
-            </div>
+            {docs && sourcePath ? (
+              <div className="mt-6 flex flex-wrap items-center gap-x-8 gap-y-2">
+                <SectionLink href={docs.href} label={`docs: ${docs.label}`} />
+                <SectionLink
+                  href={`${GITHUB_BASE}${encodeURI(sourcePath)}`}
+                  label="source on GitHub"
+                />
+              </div>
+            ) : null}
             {meta ? (
-              <MetaAside className="mt-8 max-w-2xl">{meta}</MetaAside>
+              <MetaAside className="mt-8 max-w-2xl" variant="comment">
+                {meta}
+              </MetaAside>
             ) : null}
           </div>
         </div>

--- a/apps/web/app/[locale]/(playground)/hero-readout.tsx
+++ b/apps/web/app/[locale]/(playground)/hero-readout.tsx
@@ -1,5 +1,6 @@
 import { connection } from "next/server";
 import { Suspense } from "react";
+import { BakeSwatch } from "./bake-swatch";
 import { formatStamp } from "./format";
 import { getBake } from "./shell/bake";
 
@@ -36,7 +37,7 @@ export async function HeroReadout() {
         and `tabular-nums` stops the digits shuffling as the seconds change.
       */}
       <p className="h-6">
-        <span>bake</span>{" "}
+        <span>bake</span> <BakeSwatch className="mr-1" id={bake.id} />
         <span className="font-medium text-ht-cyan-800 dark:text-ht-cyan-200">
           #{bake.id}
         </span>

--- a/apps/web/app/[locale]/(playground)/hero-readout.tsx
+++ b/apps/web/app/[locale]/(playground)/hero-readout.tsx
@@ -7,10 +7,14 @@ import { getBake } from "./shell/bake";
 async function StreamedNow() {
   await connection();
   return (
-    <>
+    // .ht-land: the arrival is this line's entire message, so it announces
+    // itself with the same wash the bake stamp uses. Pure CSS on mount — it
+    // fires when the streamed HTML is inserted, before hydration, and again
+    // whenever a refresh re-streams the line with a new timestamp.
+    <span className="ht-land">
       this line streamed in just for you —{" "}
       <span className="tabular-nums">{formatStamp(new Date())}</span>
-    </>
+    </span>
   );
 }
 
@@ -50,7 +54,13 @@ export async function HeroReadout() {
       </p>
       <p className="h-6">
         <Suspense
-          fallback={<span className="opacity-50">waiting for the server…</span>}
+          fallback={
+            // Pulsing so it reads as in-flight, not as a finished sentence;
+            // reduced motion keeps the static half-opacity as the base.
+            <span className="opacity-50 motion-safe:animate-pulse">
+              waiting for the server…
+            </span>
+          }
         >
           <StreamedNow />
         </Suspense>

--- a/apps/web/app/[locale]/(playground)/image/og-demo.tsx
+++ b/apps/web/app/[locale]/(playground)/image/og-demo.tsx
@@ -6,11 +6,17 @@ import { Label } from "@repo/design-system/components/ui/label";
 import { cn } from "@repo/design-system/lib/utils";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { DEFAULT_OG_TITLE } from "@/app/api/og/title";
+import { LivePanel } from "../live-panel";
 
 interface GeneratedImage {
   bytes: number;
   type: string;
   url: string;
+}
+
+interface OgDemoProps {
+  /** The instrument's reference bar — code drawer plus docs/source links. */
+  references?: React.ReactNode;
 }
 
 const BYTES_PER_KB = 1024;
@@ -20,12 +26,17 @@ function formatKb(bytes: number): string {
 }
 
 /**
- * Types a title, requests `/api/og?title=…`, shows the PNG the server just
- * invented — on an image-viewer checkerboard, with the file's own facts read
- * from the response. The interesting part is the URL: it's a plain GET
- * endpoint, so the link opens the same file the crawlers see.
+ * Demo 05's instrument. Types a title, requests `/api/og?title=…`, shows the
+ * PNG the server just invented — on an image-viewer checkerboard, with the
+ * file's own facts read from the response. The interesting part is the URL:
+ * it's a plain GET endpoint, so the link opens the same file the crawlers
+ * see.
+ *
+ * Owns the panel chrome because the gauge follows its fetch state: the form
+ * is the deck, the PNG is the specimen, and the pipeline facts (including
+ * Satori's flexbox limit) are the narration line.
  */
-export function OgDemo() {
+export function OgDemo({ references }: OgDemoProps) {
   const [draft, setDraft] = useState("");
   const [title, setTitle] = useState(DEFAULT_OG_TITLE);
   const [image, setImage] = useState<GeneratedImage | null>(null);
@@ -100,79 +111,94 @@ export function OgDemo() {
     []
   );
 
+  const deck = (
+    <form className="flex flex-col gap-3 sm:flex-row" onSubmit={generate}>
+      <div className="flex-1">
+        <Label className="sr-only" htmlFor="og-title">
+          Title for the generated image
+        </Label>
+        <Input
+          className="h-11"
+          id="og-title"
+          maxLength={120}
+          name="title"
+          onChange={handleDraftChange}
+          placeholder={DEFAULT_OG_TITLE}
+          type="text"
+          value={draft}
+        />
+      </div>
+      <Button className="h-11 px-6" disabled={loading} type="submit">
+        {loading ? "Rendering…" : "Generate the image"}
+      </Button>
+    </form>
+  );
+
   return (
-    <div className="flex flex-col gap-4">
-      <form className="flex flex-col gap-3 sm:flex-row" onSubmit={generate}>
-        <div className="flex-1">
-          <Label className="sr-only" htmlFor="og-title">
-            Title for the generated image
-          </Label>
-          <Input
-            className="h-11"
-            id="og-title"
-            maxLength={120}
-            name="title"
-            onChange={handleDraftChange}
-            placeholder={DEFAULT_OG_TITLE}
-            type="text"
-            value={draft}
-          />
-        </div>
-        <Button className="h-11 px-6" disabled={loading} type="submit">
-          {loading ? "Rendering…" : "Generate the image"}
-        </Button>
-      </form>
-      <p className="truncate font-mono text-muted-foreground text-xs">
-        GET {endpoint}
-      </p>
-      <div className="og-checker rounded-xl border border-foreground/10 p-4 sm:p-6">
-        <div className="relative overflow-hidden rounded-lg shadow-lg ring-1 ring-black/10 dark:ring-white/10">
-          {image ? (
-            /* Plain <img> with the blob we just fetched — wrapping a
+    <LivePanel
+      deck={deck}
+      references={references}
+      status={loading ? "working" : "live"}
+    >
+      <div className="flex flex-col gap-4">
+        <p className="truncate font-mono text-muted-foreground text-xs">
+          GET {endpoint}
+        </p>
+        <div className="og-checker rounded-xl border border-foreground/10 p-4 sm:p-6">
+          <div className="relative overflow-hidden rounded-lg shadow-lg ring-1 ring-black/10 dark:ring-white/10">
+            {image ? (
+              /* Plain <img> with the blob we just fetched — wrapping a
                generated PNG in next/image would optimize it twice. */
-            // biome-ignore lint/performance/noImgElement: the demo shows the raw route handler output
-            <img
-              alt={`Open Graph card generated from the title: ${title}`}
-              className={cn(
-                "block aspect-[1200/630] w-full transition-opacity duration-300",
-                loading && "opacity-40"
-              )}
-              height={630}
-              src={image.url}
-              width={1200}
-            />
-          ) : (
-            <div className="flex aspect-[1200/630] w-full items-center justify-center bg-background/60">
-              <span className="font-mono text-muted-foreground text-xs">
-                {error ?? "asking the server for a PNG…"}
-              </span>
-            </div>
-          )}
-          {loading && image ? (
-            <div className="absolute inset-0 flex items-center justify-center">
-              <span className="rounded-full bg-background/80 px-4 py-1.5 font-mono text-muted-foreground text-xs">
-                satori is drawing…
-              </span>
-            </div>
-          ) : null}
+              // biome-ignore lint/performance/noImgElement: the demo shows the raw route handler output
+              <img
+                alt={`Open Graph card generated from the title: ${title}`}
+                className={cn(
+                  "block aspect-[1200/630] w-full transition-opacity duration-300",
+                  loading && "opacity-40"
+                )}
+                height={630}
+                src={image.url}
+                width={1200}
+              />
+            ) : (
+              <div className="flex aspect-[1200/630] w-full items-center justify-center bg-background/60">
+                <span className="font-mono text-muted-foreground text-xs">
+                  {error ?? "asking the server for a PNG…"}
+                </span>
+              </div>
+            )}
+            {loading && image ? (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className="rounded-full bg-background/80 px-4 py-1.5 font-mono text-muted-foreground text-xs">
+                  satori is drawing…
+                </span>
+              </div>
+            ) : null}
+          </div>
         </div>
+        <div className="flex flex-wrap items-baseline justify-between gap-x-6 gap-y-2 font-mono text-muted-foreground text-xs">
+          <span>
+            {error ??
+              (image
+                ? `og.png · 1200 × 630 · ${image.type} · ${formatKb(image.bytes)}`
+                : "og.png · 1200 × 630")}
+          </span>
+          <a
+            className="text-ht-cyan-800/85 transition-colors hover:text-ht-cyan-700 dark:text-ht-cyan-300/85 dark:hover:text-ht-cyan-200"
+            href={endpoint}
+            rel="noreferrer"
+            target="_blank"
+          >
+            open the file ↗
+          </a>
+        </div>
+        {/* The pipeline, narrated — implementation limits live here, where
+            they read as specification. */}
+        <p className="font-mono text-muted-foreground text-xs/5">
+          JSX → Satori (flexbox only) → PNG · rendered per request, cached by
+          nobody
+        </p>
       </div>
-      <div className="flex flex-wrap items-baseline justify-between gap-x-6 gap-y-2 font-mono text-muted-foreground text-xs">
-        <span>
-          {error ??
-            (image
-              ? `og.png · 1200 × 630 · ${image.type} · ${formatKb(image.bytes)}`
-              : "og.png · 1200 × 630")}
-        </span>
-        <a
-          className="text-ht-cyan-800/85 transition-colors hover:text-ht-cyan-700 dark:text-ht-cyan-300/85 dark:hover:text-ht-cyan-200"
-          href={endpoint}
-          rel="noreferrer"
-          target="_blank"
-        >
-          open the file ↗
-        </a>
-      </div>
-    </div>
+    </LivePanel>
   );
 }

--- a/apps/web/app/[locale]/(playground)/image/og-demo.tsx
+++ b/apps/web/app/[locale]/(playground)/image/og-demo.tsx
@@ -60,7 +60,7 @@ export function OgDemo() {
       })
       .catch(() => {
         if (!cancelled) {
-          setError("The server couldn't draw that one. Try another title.");
+          setError("The server couldn’t draw that one. Try another title.");
         }
       })
       .finally(() => {

--- a/apps/web/app/[locale]/(playground)/live-panel.tsx
+++ b/apps/web/app/[locale]/(playground)/live-panel.tsx
@@ -9,17 +9,6 @@ interface LivePanelProps {
    */
   deck?: React.ReactNode;
   /**
-   * Legacy header caption. Demos migrating to the fixed grammar drop it: the
-   * prose above the panel names the subject once, and naming it again in the
-   * chrome bought nothing.
-   */
-  label?: string;
-  /**
-   * Legacy footer strip. Migrated demos concentrate their checkable facts in
-   * the captions and the source block instead of a fourth text fragment.
-   */
-  readout?: React.ReactNode;
-  /**
    * The bottom zone: a ReferenceBar holding the code drawer and the docs and
    * source links — the status bar every editor ends in. The exhibit's whole
    * engineering surface lives in one chassis.
@@ -47,8 +36,6 @@ export function LivePanel({
   children,
   className,
   deck,
-  label,
-  readout,
   references,
   status = "live",
   viewControls,
@@ -87,21 +74,12 @@ export function LivePanel({
           </span>
           {working ? "working" : "live"}
         </span>
-        {viewControls ?? (
-          <span className="truncate font-mono text-muted-foreground/70 text-xs">
-            {label}
-          </span>
-        )}
+        {viewControls}
       </figcaption>
       <div className="p-5 sm:p-6">{children}</div>
       {deck ? (
         <div className="border-foreground/10 border-t px-4 py-4 sm:px-5">
           {deck}
-        </div>
-      ) : null}
-      {readout ? (
-        <div className="border-foreground/10 border-t bg-muted/30 px-4 py-3 font-mono text-ht-cyan-800/85 text-xs/5 sm:px-5 dark:text-ht-cyan-300/85">
-          {readout}
         </div>
       ) : null}
       {references ? (

--- a/apps/web/app/[locale]/(playground)/live-panel.tsx
+++ b/apps/web/app/[locale]/(playground)/live-panel.tsx
@@ -24,6 +24,10 @@ export function LivePanel({
     <figure
       className={cn(
         "overflow-hidden rounded-2xl border border-foreground/10 bg-background shadow-sm",
+        // The instrument warms slightly under the cursor. It is the only
+        // hover state on a non-interactive element on this page — it marks
+        // the panel as the thing you are meant to reach for.
+        "transition-colors duration-300 hover:border-foreground/20",
         className
       )}
     >

--- a/apps/web/app/[locale]/(playground)/live-panel.tsx
+++ b/apps/web/app/[locale]/(playground)/live-panel.tsx
@@ -20,6 +20,12 @@ interface LivePanelProps {
    */
   readout?: React.ReactNode;
   /**
+   * The bottom zone: a ReferenceBar holding the code drawer and the docs and
+   * source links — the status bar every editor ends in. The exhibit's whole
+   * engineering surface lives in one chassis.
+   */
+  references?: React.ReactNode;
+  /**
    * The header gauge. `working` means a server round trip is in flight right
    * now — the dot turns amber and says so. There is exactly one such signal
    * per instrument, and this is it.
@@ -43,6 +49,7 @@ export function LivePanel({
   deck,
   label,
   readout,
+  references,
   status = "live",
   viewControls,
 }: LivePanelProps) {
@@ -95,6 +102,11 @@ export function LivePanel({
       {readout ? (
         <div className="border-foreground/10 border-t bg-muted/30 px-4 py-3 font-mono text-ht-cyan-800/85 text-xs/5 sm:px-5 dark:text-ht-cyan-300/85">
           {readout}
+        </div>
+      ) : null}
+      {references ? (
+        <div className="border-foreground/10 border-t bg-muted/40">
+          {references}
         </div>
       ) : null}
     </figure>

--- a/apps/web/app/[locale]/(playground)/live-panel.tsx
+++ b/apps/web/app/[locale]/(playground)/live-panel.tsx
@@ -3,23 +3,50 @@ import { cn } from "@repo/design-system/lib/utils";
 interface LivePanelProps {
   children: React.ReactNode;
   className?: string;
-  /** Short mono caption shown in the panel header, e.g. "runs on this page". */
-  label: string;
-  /** Server-reported facts rendered in the footer strip. */
+  /**
+   * Interactive strip pinned to the bottom of the instrument — actions only,
+   * in execution order. Hands always go to the same place.
+   */
+  deck?: React.ReactNode;
+  /**
+   * Legacy header caption. Demos migrating to the fixed grammar drop it: the
+   * prose above the panel names the subject once, and naming it again in the
+   * chrome bought nothing.
+   */
+  label?: string;
+  /**
+   * Legacy footer strip. Migrated demos concentrate their checkable facts in
+   * the captions and the source block instead of a fourth text fragment.
+   */
   readout?: React.ReactNode;
+  /**
+   * The header gauge. `working` means a server round trip is in flight right
+   * now — the dot turns amber and says so. There is exactly one such signal
+   * per instrument, and this is it.
+   */
+  status?: "live" | "working";
+  /**
+   * View controls, pinned top-right of the chrome — the corner every editor
+   * keeps its view switches in. Actions never live here.
+   */
+  viewControls?: React.ReactNode;
 }
 
 /**
- * The instrument chrome every demo sits in. The header says it's live, the
- * footer reports what the server actually did. If a panel can't honestly fill
- * its readout, it doesn't belong on this page.
+ * The instrument chrome every demo sits in. The fixed grammar: state
+ * top-left, view controls top-right, the specimen in the body, actions in
+ * the bottom deck. A visitor who has used one instrument has used them all.
  */
 export function LivePanel({
   children,
   className,
+  deck,
   label,
   readout,
+  status = "live",
+  viewControls,
 }: LivePanelProps) {
+  const working = status === "working";
   return (
     <figure
       className={cn(
@@ -31,19 +58,40 @@ export function LivePanel({
         className
       )}
     >
-      <figcaption className="flex items-center justify-between gap-4 border-foreground/10 border-b bg-muted/40 px-4 py-2.5 sm:px-5">
+      <figcaption className="flex min-h-11 items-center justify-between gap-4 border-foreground/10 border-b bg-muted/40 px-4 py-2 sm:px-5">
         <span className="flex items-center gap-2.5 font-mono font-semibold text-[0.7rem] text-muted-foreground uppercase tracking-[0.2em]">
           <span aria-hidden="true" className="relative flex size-2">
-            <span className="absolute inline-flex size-full rounded-full bg-ht-cyan-500/50 motion-safe:animate-ping" />
-            <span className="relative inline-flex size-2 rounded-full bg-ht-cyan-600 dark:bg-ht-cyan-400" />
+            <span
+              className={cn(
+                "absolute inline-flex size-full rounded-full motion-safe:animate-ping",
+                working
+                  ? "bg-(--color-hastoggle-orange)/60"
+                  : "bg-ht-cyan-500/50"
+              )}
+            />
+            <span
+              className={cn(
+                "relative inline-flex size-2 rounded-full",
+                working
+                  ? "bg-(--color-hastoggle-orange)"
+                  : "bg-ht-cyan-600 dark:bg-ht-cyan-400"
+              )}
+            />
           </span>
-          live
+          {working ? "working" : "live"}
         </span>
-        <span className="truncate font-mono text-muted-foreground/70 text-xs">
-          {label}
-        </span>
+        {viewControls ?? (
+          <span className="truncate font-mono text-muted-foreground/70 text-xs">
+            {label}
+          </span>
+        )}
       </figcaption>
       <div className="p-5 sm:p-6">{children}</div>
+      {deck ? (
+        <div className="border-foreground/10 border-t px-4 py-4 sm:px-5">
+          {deck}
+        </div>
+      ) : null}
       {readout ? (
         <div className="border-foreground/10 border-t bg-muted/30 px-4 py-3 font-mono text-ht-cyan-800/85 text-xs/5 sm:px-5 dark:text-ht-cyan-300/85">
           {readout}

--- a/apps/web/app/[locale]/(playground)/mutation/press-count.tsx
+++ b/apps/web/app/[locale]/(playground)/mutation/press-count.tsx
@@ -19,7 +19,7 @@ export async function PressCount() {
         </span>
       </p>
       <p className="font-mono text-muted-foreground text-xs/5">
-        read server-side from an httpOnly cookie — your JavaScript can&apos;t
+        read server-side from an httpOnly cookie — your JavaScript can&rsquo;t
         even see it
       </p>
     </div>

--- a/apps/web/app/[locale]/(playground)/mutation/press-form.tsx
+++ b/apps/web/app/[locale]/(playground)/mutation/press-form.tsx
@@ -22,7 +22,7 @@ export function PressForm() {
         </MarketingButton>
       </div>
       <p className="font-mono text-muted-foreground text-xs/5">
-        works with JavaScript switched off — try it, we&apos;ll wait
+        works with JavaScript switched off — try it, we&rsquo;ll wait
       </p>
     </form>
   );

--- a/apps/web/app/[locale]/(playground)/reference-bar.tsx
+++ b/apps/web/app/[locale]/(playground)/reference-bar.tsx
@@ -1,0 +1,31 @@
+import { SectionLink } from "./section-link";
+
+interface ReferenceBarProps {
+  /** The code drawer (a CodeBlock with variant="bar"). */
+  children: React.ReactNode;
+  docsHref: string;
+  sourceHref: string;
+}
+
+/**
+ * The instrument's bottom zone — a status bar, like the one every editor
+ * ends in. The code drawer's disclosure sits on the left; docs and source
+ * links pin to the right, absolutely positioned over the summary row so
+ * clicking them never toggles the drawer. Row height matches the chrome
+ * header (h-11), so the chassis opens and closes on the same beat.
+ */
+export function ReferenceBar({
+  children,
+  docsHref,
+  sourceHref,
+}: ReferenceBarProps) {
+  return (
+    <div className="relative">
+      {children}
+      <div className="absolute top-0 right-0 flex h-11 items-center gap-5 px-4 sm:px-5">
+        <SectionLink href={docsHref} label="docs" />
+        <SectionLink href={sourceHref} label="source" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/[locale]/(playground)/section-link.tsx
+++ b/apps/web/app/[locale]/(playground)/section-link.tsx
@@ -1,0 +1,24 @@
+interface SectionLinkProps {
+  href: string;
+  label: string;
+}
+
+/** External reference in the instrument register: arrow, mono, quiet. */
+export function SectionLink({ href, label }: SectionLinkProps) {
+  return (
+    <a
+      className="group inline-flex items-baseline gap-2 font-mono text-muted-foreground text-xs transition-colors hover:text-foreground"
+      href={href}
+      rel="noreferrer"
+      target="_blank"
+    >
+      <span
+        aria-hidden="true"
+        className="text-ht-cyan-700/70 transition-colors group-hover:text-ht-cyan-700 dark:text-ht-cyan-300/70 dark:group-hover:text-ht-cyan-300"
+      >
+        ↗
+      </span>
+      {label}
+    </a>
+  );
+}

--- a/apps/web/app/[locale]/(playground)/shell/bake.ts
+++ b/apps/web/app/[locale]/(playground)/shell/bake.ts
@@ -11,6 +11,9 @@ export interface Bake {
  * cache lifetime runs out. The random id exists so a re-bake is undeniable —
  * timestamps invite squinting, fingerprints don't.
  *
+ * Six hex characters, so the fingerprint IS a CSS color — the swatch beside
+ * it renders the literal value, nothing derived, nothing truncated.
+ *
  * The hero and the shell demo both read this, so they can never disagree.
  */
 // biome-ignore lint/suspicious/useAwait: `use cache` only works on async functions, even when nothing awaits
@@ -21,6 +24,6 @@ export async function getBake(): Promise<Bake> {
 
   return {
     bakedAt: new Date().toISOString(),
-    id: crypto.randomUUID().slice(0, 8),
+    id: crypto.randomUUID().slice(0, 6),
   };
 }

--- a/apps/web/app/[locale]/(playground)/shell/baked-stamp.tsx
+++ b/apps/web/app/[locale]/(playground)/shell/baked-stamp.tsx
@@ -1,3 +1,4 @@
+import { BakeSwatch } from "../bake-swatch";
 import { formatStamp } from "../format";
 import type { Bake } from "./bake";
 
@@ -15,7 +16,7 @@ export function BakedStamp({ bake }: BakedStampProps) {
   return (
     <div className="flex flex-col gap-4">
       <p className="font-display font-medium text-4xl text-foreground tracking-tight sm:text-5xl">
-        bake{" "}
+        bake <BakeSwatch className="mr-1 align-[0.02em]" id={bake.id} />
         <span className="text-ht-cyan-700 dark:text-ht-cyan-300">
           #{bake.id}
         </span>

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
@@ -9,8 +9,8 @@ import {
 import type { RebakeState } from "./rebake-state";
 
 const EXPIRED_AT = "2026-08-10T15:05:35.000Z";
-const CURRENT_ID = "a020a685";
-const PRIVATE_ID = "1e472bda";
+const CURRENT_ID = "a020a6";
+const PRIVATE_ID = "1e472b";
 
 const SIMPLE_FRESH: RebakeState = {
   hasCompletedCycle: false,

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
@@ -4,6 +4,7 @@ import {
   DETAIL_VARIANTS,
   REBAKE_FAILED_CAPTION,
   readout,
+  SETTLING_READOUT,
 } from "./rebake-copy";
 import type { RebakeState } from "./rebake-state";
 
@@ -95,6 +96,7 @@ describe("rebake readout", () => {
       readout(MACHINERY_EXPIRED, CURRENT_ID).caption,
       readout(MACHINERY_REFETCHED, CURRENT_ID).caption,
       REBAKE_FAILED_CAPTION,
+      SETTLING_READOUT.caption,
     ];
     for (const caption of shown) {
       expect(CAPTION_VARIANTS).toContain(caption);
@@ -109,10 +111,18 @@ describe("rebake readout", () => {
       readout(MACHINERY_SERVED, CURRENT_ID).detail,
       readout(MACHINERY_EXPIRED, CURRENT_ID).detail,
       readout(MACHINERY_REFETCHED, CURRENT_ID).detail,
+      SETTLING_READOUT.detail,
     ];
     expect(real.map((d) => d.length)).toEqual(
       DETAIL_VARIANTS.map((d) => d.length)
     );
+  });
+
+  test("the settling readout never claims the shared entry is on screen", () => {
+    // While the owed refresh is in flight, the stamp still shows the private
+    // render — the settling lines must not borrow the served claim.
+    expect(SETTLING_READOUT.detail).not.toContain("every visitor");
+    expect(SETTLING_READOUT.label).not.toBe("served");
   });
 
   test("the reveal caption points at the evidence, and only when there is evidence", () => {

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
@@ -72,7 +72,7 @@ describe("rebake readout", () => {
   test("expired explains why the private hash cannot be the refill", () => {
     expect(readout(MACHINERY_EXPIRED, CURRENT_ID)).toEqual({
       caption:
-        "the hash above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards. Ask for it.",
+        "the hash above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards — button two, a new tab, another visitor, whoever asks first. Ask for it.",
       detail:
         "at 15:05:35 UTC — the hash above was rendered for you and cached for nobody",
       label: "expired",

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
@@ -21,7 +21,7 @@ describe("rebake readout", () => {
   test("served doesn't claim to know how this render happened", () => {
     expect(readout(SERVED_STATE, CURRENT_ID)).toEqual({
       caption:
-        "expires the cache tag for everyone, instantly. Then something surprising happens.",
+        "expires the cache tag for everyone, instantly. Nothing refills it on its own.",
       detail: "from the static shell — the same entry every visitor gets",
       label: "served",
     });
@@ -30,7 +30,7 @@ describe("rebake readout", () => {
   test("expired names the moment and disclaims the private hash above it", () => {
     expect(readout(EXPIRED_STATE, CURRENT_ID)).toEqual({
       caption:
-        "the shell you killed is gone. Its replacement doesn't exist until someone asks for it. Be the someone.",
+        "the entry you expired is gone. Its replacement does not exist until someone asks for the page. Ask for it.",
       detail:
         "at 15:05:35 UTC — the hash above was rendered for you and cached for nobody",
       label: "expired",
@@ -104,7 +104,7 @@ describe("rebake readout", () => {
     };
     expect(readout(state, CURRENT_ID)).toEqual({
       caption:
-        "expires the cache tag for everyone, instantly. Then something surprising happens.",
+        "expires the cache tag for everyone, instantly. Nothing refills it on its own.",
       detail: "from the static shell — the same entry every visitor gets",
       label: "served",
     });

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
@@ -83,7 +83,7 @@ describe("rebake readout", () => {
   test("refetched discloses that the refill was a render, not an API call", () => {
     expect(readout(MACHINERY_REFETCHED, CURRENT_ID)).toEqual({
       caption:
-        "the fetch ran no cache API — the page rendered again, and this time the cache kept it. Expiring an entry and refilling it are two different events. You just watched both.",
+        "the fetch ran no cache API — the page rendered again, and this time the cache kept it. Expiring an entry and refilling it are two different events.",
       detail: `#${CURRENT_ID} is the bake above, and every visitor gets it. #${PRIVATE_ID} was yours alone, and is gone`,
       label: "served",
     });

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
@@ -30,6 +30,7 @@ const MACHINERY_SERVED: RebakeState = {
 const MACHINERY_EXPIRED: RebakeState = {
   expiredAt: EXPIRED_AT,
   hasCompletedCycle: false,
+  idAtExpiry: "0a11ed",
   mode: "machinery",
   phase: "expired",
 };

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
@@ -18,26 +18,26 @@ const EXPIRED_STATE: RebakeState = {
 };
 
 describe("rebake readout", () => {
-  test("served doesn't claim to know how this render happened", () => {
+  test("served names the handle the button is about to pull", () => {
     expect(readout(SERVED_STATE, CURRENT_ID)).toEqual({
       caption:
-        "expires the cache tag for everyone, instantly. Nothing refills it on its own.",
+        'updateTag("landing-shell") expires the entry for everyone, instantly. Nothing refills it on its own.',
       detail: "from the static shell — the same entry every visitor gets",
       label: "served",
     });
   });
 
-  test("expired names the moment and disclaims the private hash above it", () => {
+  test("expired explains why the private hash cannot be the refill", () => {
     expect(readout(EXPIRED_STATE, CURRENT_ID)).toEqual({
       caption:
-        "the entry you expired is gone. Its replacement does not exist until someone asks for the page. Ask for it.",
+        "the hash above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards. Ask for it.",
       detail:
         "at 15:05:35 UTC — the hash above was rendered for you and cached for nobody",
       label: "expired",
     });
   });
 
-  test("refetched compares what you saw against what actually persisted, without claiming credit for it", () => {
+  test("refetched discloses that the refill was a render, not an API call", () => {
     const state: RebakeState = {
       expiredAt: EXPIRED_AT,
       phase: "refetched",
@@ -45,7 +45,7 @@ describe("rebake readout", () => {
     };
     expect(readout(state, CURRENT_ID)).toEqual({
       caption:
-        "expiring an entry and refilling it are two different events. You just watched both.",
+        "the fetch ran no cache API — the page rendered again, and this time the cache kept it. Expiring an entry and refilling it are two different events. You just watched both.",
       detail: `#${CURRENT_ID} is the bake above, and every visitor gets it. #${PRIVATE_ID} was yours alone, and is gone`,
       label: "served",
     });
@@ -89,8 +89,8 @@ describe("rebake readout", () => {
       phase: "refetched",
       privateId: PRIVATE_ID,
     };
-    // The idle caption promises a surprise; once the surprise is on screen,
-    // still promising it reads as though the panel missed its own reveal.
+    // The idle caption describes what pressing will do; once the reveal is on
+    // screen, repeating it reads as though the panel missed its own reveal.
     expect(readout(revealed, CURRENT_ID).caption).not.toBe(
       readout(SERVED_STATE, CURRENT_ID).caption
     );
@@ -104,7 +104,7 @@ describe("rebake readout", () => {
     };
     expect(readout(state, CURRENT_ID)).toEqual({
       caption:
-        "expires the cache tag for everyone, instantly. Nothing refills it on its own.",
+        'updateTag("landing-shell") expires the entry for everyone, instantly. Nothing refills it on its own.',
       detail: "from the static shell — the same entry every visitor gets",
       label: "served",
     });

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
@@ -72,7 +72,7 @@ describe("rebake readout", () => {
   test("expired explains why the private hash cannot be the refill", () => {
     expect(readout(MACHINERY_EXPIRED, CURRENT_ID)).toEqual({
       caption:
-        "the hash above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards — button two, a new tab, another visitor, whoever asks first. Ask for it.",
+        "the bake above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards — button two, a new tab, another visitor, whoever asks first. Ask for it.",
       detail:
         "at 15:05:35 UTC — the hash above was rendered for you and cached for nobody",
       label: "expired",

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.test.ts
@@ -11,15 +11,56 @@ const EXPIRED_AT = "2026-08-10T15:05:35.000Z";
 const CURRENT_ID = "a020a685";
 const PRIVATE_ID = "1e472bda";
 
-const SERVED_STATE: RebakeState = { phase: "served" };
-const EXPIRED_STATE: RebakeState = {
+const SIMPLE_FRESH: RebakeState = {
+  hasCompletedCycle: false,
+  mode: "simple",
+  phase: "served",
+};
+const SIMPLE_CYCLED: RebakeState = {
+  hasCompletedCycle: true,
+  mode: "simple",
+  phase: "served",
+};
+const MACHINERY_SERVED: RebakeState = {
+  hasCompletedCycle: false,
+  mode: "machinery",
+  phase: "served",
+};
+const MACHINERY_EXPIRED: RebakeState = {
   expiredAt: EXPIRED_AT,
+  hasCompletedCycle: false,
+  mode: "machinery",
   phase: "expired",
+};
+const MACHINERY_REFETCHED: RebakeState = {
+  expiredAt: EXPIRED_AT,
+  hasCompletedCycle: true,
+  mode: "machinery",
+  phase: "refetched",
+  privateId: PRIVATE_ID,
 };
 
 describe("rebake readout", () => {
-  test("served names the handle the button is about to pull", () => {
-    expect(readout(SERVED_STATE, CURRENT_ID)).toEqual({
+  test("the simple view opens by saying what one press does, fused", () => {
+    expect(readout(SIMPLE_FRESH, CURRENT_ID)).toEqual({
+      caption:
+        "throws this page’s cache entry away and bakes a fresh one — for every visitor, immediately.",
+      detail: "from the static shell — the same entry every visitor gets",
+      label: "served",
+    });
+  });
+
+  test("after a cycle, the simple view plants the hook for the switch", () => {
+    expect(readout(SIMPLE_CYCLED, CURRENT_ID)).toEqual({
+      caption:
+        "that worked — the bake above is what every visitor gets now. It felt like one event; it was three. The switch slows the next one down.",
+      detail: "from the static shell — the same entry every visitor gets",
+      label: "served",
+    });
+  });
+
+  test("the machinery view names the handle the button is about to pull", () => {
+    expect(readout(MACHINERY_SERVED, CURRENT_ID)).toEqual({
       caption:
         'updateTag("landing-shell") expires the entry for everyone, instantly. Nothing refills it on its own.',
       detail: "from the static shell — the same entry every visitor gets",
@@ -28,7 +69,7 @@ describe("rebake readout", () => {
   });
 
   test("expired explains why the private hash cannot be the refill", () => {
-    expect(readout(EXPIRED_STATE, CURRENT_ID)).toEqual({
+    expect(readout(MACHINERY_EXPIRED, CURRENT_ID)).toEqual({
       caption:
         "the hash above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards. Ask for it.",
       detail:
@@ -38,12 +79,7 @@ describe("rebake readout", () => {
   });
 
   test("refetched discloses that the refill was a render, not an API call", () => {
-    const state: RebakeState = {
-      expiredAt: EXPIRED_AT,
-      phase: "refetched",
-      privateId: PRIVATE_ID,
-    };
-    expect(readout(state, CURRENT_ID)).toEqual({
+    expect(readout(MACHINERY_REFETCHED, CURRENT_ID)).toEqual({
       caption:
         "the fetch ran no cache API — the page rendered again, and this time the cache kept it. Expiring an entry and refilling it are two different events. You just watched both.",
       detail: `#${CURRENT_ID} is the bake above, and every visitor gets it. #${PRIVATE_ID} was yours alone, and is gone`,
@@ -53,12 +89,11 @@ describe("rebake readout", () => {
 
   test("every caption the panel can show is one the layout reserved space for", () => {
     const shown = [
-      readout(SERVED_STATE, CURRENT_ID).caption,
-      readout(EXPIRED_STATE, CURRENT_ID).caption,
-      readout(
-        { expiredAt: EXPIRED_AT, phase: "refetched", privateId: PRIVATE_ID },
-        CURRENT_ID
-      ).caption,
+      readout(SIMPLE_FRESH, CURRENT_ID).caption,
+      readout(SIMPLE_CYCLED, CURRENT_ID).caption,
+      readout(MACHINERY_SERVED, CURRENT_ID).caption,
+      readout(MACHINERY_EXPIRED, CURRENT_ID).caption,
+      readout(MACHINERY_REFETCHED, CURRENT_ID).caption,
       REBAKE_FAILED_CAPTION,
     ];
     for (const caption of shown) {
@@ -71,12 +106,9 @@ describe("rebake readout", () => {
     // changes a detail's length without updating its ghost, the slot stops
     // reserving the right space and the panel starts hopping again.
     const real = [
-      readout(SERVED_STATE, CURRENT_ID).detail,
-      readout(EXPIRED_STATE, CURRENT_ID).detail,
-      readout(
-        { expiredAt: EXPIRED_AT, phase: "refetched", privateId: PRIVATE_ID },
-        CURRENT_ID
-      ).detail,
+      readout(MACHINERY_SERVED, CURRENT_ID).detail,
+      readout(MACHINERY_EXPIRED, CURRENT_ID).detail,
+      readout(MACHINERY_REFETCHED, CURRENT_ID).detail,
     ];
     expect(real.map((d) => d.length)).toEqual(
       DETAIL_VARIANTS.map((d) => d.length)
@@ -84,21 +116,19 @@ describe("rebake readout", () => {
   });
 
   test("the reveal caption points at the evidence, and only when there is evidence", () => {
-    const revealed: RebakeState = {
-      expiredAt: EXPIRED_AT,
-      phase: "refetched",
-      privateId: PRIVATE_ID,
-    };
-    // The idle caption describes what pressing will do; once the reveal is on
-    // screen, repeating it reads as though the panel missed its own reveal.
-    expect(readout(revealed, CURRENT_ID).caption).not.toBe(
-      readout(SERVED_STATE, CURRENT_ID).caption
+    // The machinery idle caption describes what pressing will do; once the
+    // reveal is on screen, repeating it reads as though the panel missed its
+    // own reveal.
+    expect(readout(MACHINERY_REFETCHED, CURRENT_ID).caption).not.toBe(
+      readout(MACHINERY_SERVED, CURRENT_ID).caption
     );
   });
 
   test("refetched to the same id you already had falls back to the served line, not a comparison of a hash with itself", () => {
     const state: RebakeState = {
       expiredAt: EXPIRED_AT,
+      hasCompletedCycle: true,
+      mode: "machinery",
       phase: "refetched",
       privateId: CURRENT_ID,
     };

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
@@ -1,12 +1,20 @@
 import { formatClock } from "../format";
 import type { RebakeState } from "./rebake-state";
 
+/**
+ * The three captions are one causal arc. Idle names the handle the button is
+ * wired to; expired explains why the private render cannot be the refill (the
+ * expiry is a timestamp, and that hash predates it — verified on a preview
+ * deploy in PR #364, since `next dev` hides this); revealed discloses that the
+ * refill had no cache API in it at all. Each phase answers the question the
+ * previous one raised.
+ */
 const IDLE_CAPTION =
-  "expires the cache tag for everyone, instantly. Nothing refills it on its own.";
+  'updateTag("landing-shell") expires the entry for everyone, instantly. Nothing refills it on its own.';
 const EXPIRED_CAPTION =
-  "the entry you expired is gone. Its replacement does not exist until someone asks for the page. Ask for it.";
+  "the hash above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards. Ask for it.";
 const REVEALED_CAPTION =
-  "expiring an entry and refilling it are two different events. You just watched both.";
+  "the fetch ran no cache API — the page rendered again, and this time the cache kept it. Expiring an entry and refilling it are two different events. You just watched both.";
 
 /**
  * Replaces the caption when the action never came back, so a failure lands in

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
@@ -13,7 +13,7 @@ const REVEALED_CAPTION =
  * the slot the visitor is already reading instead of adding a line and moving
  * everything below it.
  */
-export const REBAKE_FAILED_CAPTION = "the re-bake didn't come back. Try again?";
+export const REBAKE_FAILED_CAPTION = "the re-bake didn’t come back. Try again?";
 
 interface Readout {
   caption: string;

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
@@ -35,6 +35,21 @@ interface Readout {
   label: string;
 }
 
+/**
+ * Shown while the switch is settling an expiry the visitor left open: the
+ * view flips to simple immediately (the switch has to answer the hand), and
+ * this readout covers the window until the owed refresh lands — because for
+ * that window the served line would be claiming a shared entry the stamp
+ * isn't showing yet.
+ */
+export const SETTLING_READOUT: Readout = {
+  caption:
+    "settling the expiry you left open — the same quiet refresh a mutation normally ends with.",
+  detail:
+    "the hash above is still the private one — its replacement is in flight",
+  label: "asking",
+};
+
 const SERVED_DETAIL =
   "from the static shell — the same entry every visitor gets";
 
@@ -79,12 +94,14 @@ export const CAPTION_VARIANTS: readonly string[] = [
   EXPIRED_CAPTION,
   REVEALED_CAPTION,
   REBAKE_FAILED_CAPTION,
+  SETTLING_READOUT.caption,
 ];
 
 export const DETAIL_VARIANTS: readonly string[] = [
   SERVED_DETAIL,
   expiredDetail(PLACEHOLDER_CLOCK),
   revealedDetail(PLACEHOLDER_ID, PLACEHOLDER_ID),
+  SETTLING_READOUT.detail,
 ];
 
 /**

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
@@ -20,7 +20,7 @@ const MACHINERY_IDLE_CAPTION =
 const EXPIRED_CAPTION =
   "the bake above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards — button two, a new tab, another visitor, whoever asks first. Ask for it.";
 const REVEALED_CAPTION =
-  "the fetch ran no cache API — the page rendered again, and this time the cache kept it. Expiring an entry and refilling it are two different events. You just watched both.";
+  "the fetch ran no cache API — the page rendered again, and this time the cache kept it. Expiring an entry and refilling it are two different events.";
 
 /**
  * Replaces the caption when the action never came back, so a failure lands in

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
@@ -80,12 +80,12 @@ function revealedDetail(privateId: string, currentId: string): string {
  * reserved together, so flipping the switch doesn't move the page either.
  *
  * The placeholders are the same width as the real values (a clock is always
- * `HH:MM:SS`, a bake id always eight hex characters), so the ghosts wrap
- * exactly where the real thing will. `rebake-copy.test.ts` holds that
- * property still.
+ * `HH:MM:SS`, a bake id always six hex characters — a CSS color), so the
+ * ghosts wrap exactly where the real thing will. `rebake-copy.test.ts` holds
+ * that property still.
  */
 const PLACEHOLDER_CLOCK = "00:00:00 UTC";
-const PLACEHOLDER_ID = "00000000";
+const PLACEHOLDER_ID = "000000";
 
 export const CAPTION_VARIANTS: readonly string[] = [
   SIMPLE_IDLE_CAPTION,

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
@@ -18,7 +18,7 @@ const SIMPLE_CYCLED_CAPTION =
 const MACHINERY_IDLE_CAPTION =
   'updateTag("landing-shell") expires the entry for everyone, instantly. Nothing refills it on its own.';
 const EXPIRED_CAPTION =
-  "the hash above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards — button two, a new tab, another visitor, whoever asks first. Ask for it.";
+  "the bake above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards — button two, a new tab, another visitor, whoever asks first. Ask for it.";
 const REVEALED_CAPTION =
   "the fetch ran no cache API — the page rendered again, and this time the cache kept it. Expiring an entry and refilling it are two different events. You just watched both.";
 
@@ -46,7 +46,7 @@ export const SETTLING_READOUT: Readout = {
   caption:
     "settling the expiry you left open — the same quiet refresh a mutation normally ends with.",
   detail:
-    "the hash above is still the private one — its replacement is in flight",
+    "the bake above is still the private one — its replacement is in flight",
   label: "asking",
 };
 

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
@@ -2,14 +2,20 @@ import { formatClock } from "../format";
 import type { RebakeState } from "./rebake-state";
 
 /**
- * The three captions are one causal arc. Idle names the handle the button is
- * wired to; expired explains why the private render cannot be the refill (the
- * expiry is a timestamp, and that hash predates it — verified on a preview
- * deploy in PR #364, since `next dev` hides this); revealed discloses that the
- * refill had no cache API in it at all. Each phase answers the question the
- * previous one raised.
+ * Two views, one arc. The simple captions describe the fused flow real apps
+ * ship — a press that expires and refills in one round trip — and, once the
+ * visitor has seen it work, hand them the switch. The machinery captions are
+ * the same story slowed down: idle names the handle the button is wired to;
+ * expired explains why the private render cannot be the refill (the expiry is
+ * a timestamp, and that hash predates it — verified on a preview deploy in
+ * PR #364, since `next dev` hides this); revealed discloses that the refill
+ * had no cache API in it at all.
  */
-const IDLE_CAPTION =
+const SIMPLE_IDLE_CAPTION =
+  "throws this page’s cache entry away and bakes a fresh one — for every visitor, immediately.";
+const SIMPLE_CYCLED_CAPTION =
+  "that worked — the bake above is what every visitor gets now. It felt like one event; it was three. The switch slows the next one down.";
+const MACHINERY_IDLE_CAPTION =
   'updateTag("landing-shell") expires the entry for everyone, instantly. Nothing refills it on its own.';
 const EXPIRED_CAPTION =
   "the hash above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards. Ask for it.";
@@ -32,8 +38,8 @@ interface Readout {
 const SERVED_DETAIL =
   "from the static shell — the same entry every visitor gets";
 
-const SERVED_READOUT: Readout = {
-  caption: IDLE_CAPTION,
+const MACHINERY_SERVED_READOUT: Readout = {
+  caption: MACHINERY_IDLE_CAPTION,
   detail: SERVED_DETAIL,
   label: "served",
 };
@@ -55,7 +61,8 @@ function revealedDetail(privateId: string, currentId: string): string {
 /**
  * Every string each slot could hold, for the panel to stack invisibly behind
  * the live one so the slot is always as tall as its worst case — at every
- * viewport, not just the ones someone measured.
+ * viewport, not just the ones someone measured. Captions from both views are
+ * reserved together, so flipping the switch doesn't move the page either.
  *
  * The placeholders are the same width as the real values (a clock is always
  * `HH:MM:SS`, a bake id always eight hex characters), so the ghosts wrap
@@ -66,7 +73,9 @@ const PLACEHOLDER_CLOCK = "00:00:00 UTC";
 const PLACEHOLDER_ID = "00000000";
 
 export const CAPTION_VARIANTS: readonly string[] = [
-  IDLE_CAPTION,
+  SIMPLE_IDLE_CAPTION,
+  SIMPLE_CYCLED_CAPTION,
+  MACHINERY_IDLE_CAPTION,
   EXPIRED_CAPTION,
   REVEALED_CAPTION,
   REBAKE_FAILED_CAPTION,
@@ -80,9 +89,19 @@ export const DETAIL_VARIANTS: readonly string[] = [
 
 /**
  * The provenance line, which is the only part of the demo that has to change
- * per phase — the stamp above states facts that survive all three.
+ * per phase — the stamp above states facts that survive every phase of both
+ * views.
  */
 export function readout(state: RebakeState, currentId: string): Readout {
+  if (state.mode === "simple") {
+    return {
+      caption: state.hasCompletedCycle
+        ? SIMPLE_CYCLED_CAPTION
+        : SIMPLE_IDLE_CAPTION,
+      detail: SERVED_DETAIL,
+      label: "served",
+    };
+  }
   if (state.phase === "expired") {
     return {
       caption: EXPIRED_CAPTION,
@@ -95,7 +114,7 @@ export function readout(state: RebakeState, currentId: string): Readout {
     // window between your expiry and your fetch, so the same id back is not
     // a bug — it's just nothing left to compare.
     if (state.privateId === currentId) {
-      return SERVED_READOUT;
+      return MACHINERY_SERVED_READOUT;
     }
     return {
       caption: REVEALED_CAPTION,
@@ -103,5 +122,5 @@ export function readout(state: RebakeState, currentId: string): Readout {
       label: "served",
     };
   }
-  return SERVED_READOUT;
+  return MACHINERY_SERVED_READOUT;
 }

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
@@ -2,9 +2,9 @@ import { formatClock } from "../format";
 import type { RebakeState } from "./rebake-state";
 
 const IDLE_CAPTION =
-  "expires the cache tag for everyone, instantly. Then something surprising happens.";
+  "expires the cache tag for everyone, instantly. Nothing refills it on its own.";
 const EXPIRED_CAPTION =
-  "the shell you killed is gone. Its replacement doesn't exist until someone asks for it. Be the someone.";
+  "the entry you expired is gone. Its replacement does not exist until someone asks for the page. Ask for it.";
 const REVEALED_CAPTION =
   "expiring an entry and refilling it are two different events. You just watched both.";
 

--- a/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-copy.ts
@@ -18,7 +18,7 @@ const SIMPLE_CYCLED_CAPTION =
 const MACHINERY_IDLE_CAPTION =
   'updateTag("landing-shell") expires the entry for everyone, instantly. Nothing refills it on its own.';
 const EXPIRED_CAPTION =
-  "the hash above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards. Ask for it.";
+  "the hash above was rendered before your expiry landed, so the cache will not keep it. The refill is the first render that starts afterwards — button two, a new tab, another visitor, whoever asks first. Ask for it.";
 const REVEALED_CAPTION =
   "the fetch ran no cache API — the page rendered again, and this time the cache kept it. Expiring an entry and refilling it are two different events. You just watched both.";
 

--- a/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
@@ -11,6 +11,7 @@ import {
   DETAIL_VARIANTS,
   REBAKE_FAILED_CAPTION,
   readout,
+  SETTLING_READOUT,
 } from "./rebake-copy";
 import {
   canFetch,
@@ -132,18 +133,23 @@ export function RebakePanel({ currentId }: RebakePanelProps) {
   }, [machinery, rebakeLocked, router]);
 
   const handleToggle = useCallback(() => {
-    if (canFetch(state)) {
+    const leavesGapOpen = canFetch(state);
+    // The flip itself stays OUT of the transition: it is client-owned state,
+    // and inside one it would not paint until router.refresh() resolved —
+    // the switch sat frozen for the whole round trip. Only the server sync
+    // is transitional; while it flies, `isFetching` swaps in the settling
+    // readout so the flipped view doesn't claim a shared entry the stamp
+    // isn't showing yet.
+    dispatch({ type: "toggled" });
+    if (leavesGapOpen) {
       // Leaving the machinery view with an expiry unanswered: settle it on
       // the way out — quietly finishing the round trip is exactly what real
       // apps do — so the simple view never rests showing a render the cache
       // refused to keep.
       startFetch(() => {
-        dispatch({ type: "toggled" });
         router.refresh();
       });
-      return;
     }
-    dispatch({ type: "toggled" });
   }, [router, state]);
 
   const handleFetch = useCallback(() => {
@@ -156,7 +162,13 @@ export function RebakePanel({ currentId }: RebakePanelProps) {
     });
   }, [currentId, router]);
 
-  const { caption, detail, label } = readout(state, currentId);
+  // A fetch transition still flying after the mode flipped to simple is the
+  // settling window: the owed refresh is out, and the stamp is still the
+  // private render until it lands.
+  const settling = isFetching && !machinery;
+  const { caption, detail, label } = settling
+    ? SETTLING_READOUT
+    : readout(state, currentId);
   const rebakeLabel = isRebaking ? REBAKE_LABELS[1] : REBAKE_LABELS[0];
   const fetchLabel = isFetching ? FETCH_LABELS[1] : FETCH_LABELS[0];
   const captionText = rebakeFailed ? REBAKE_FAILED_CAPTION : caption;

--- a/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Switch } from "@repo/design-system/components/ui/switch";
 import { cn } from "@repo/design-system/lib/utils";
 import { useRouter } from "next/navigation";
 import { useCallback, useReducer, useState, useTransition } from "react";
@@ -75,9 +76,10 @@ interface RebakePanelProps {
 }
 
 /**
- * Expiring a tag and refilling it are separate events, so they get separate
- * buttons — and the button you can't press is doing as much teaching as the
- * one you can.
+ * One mechanism, two views, chosen by a switch. The simple view fuses the
+ * expiry and the refill into one press — the flow real apps ship. The
+ * machinery view gives the two events separate buttons, and the button you
+ * can't press is doing as much teaching as the one you can.
  *
  * Every slot in here is sized for its tallest and widest state, because a
  * demo about cache timing is unreadable if the thing you are watching hops
@@ -90,6 +92,7 @@ export function RebakePanel({ currentId }: RebakePanelProps) {
   const [isFetching, startFetch] = useTransition();
   const [rebakeFailed, setRebakeFailed] = useState(false);
 
+  const machinery = state.mode === "machinery";
   const rebakeLocked = !canRebake(state) || isRebaking;
   const fetchable = canFetch(state);
 
@@ -100,17 +103,48 @@ export function RebakePanel({ currentId }: RebakePanelProps) {
       return;
     }
     setRebakeFailed(false);
+    if (machinery) {
+      startRebake(async () => {
+        try {
+          const { rebakedAt } = await rebakeShell();
+          dispatch({ at: rebakedAt, type: "expired" });
+        } catch {
+          // The tag may well have been expired before the response died, so
+          // the copy promises nothing about what happened — it just says so.
+          setRebakeFailed(true);
+        }
+      });
+      return;
+    }
+    // The fused press: the same action, with the refill it implies chained
+    // into the same transition. The button stays "Re-baking…" across both
+    // halves, so the press reads as the one event it is pretending to be.
     startRebake(async () => {
       try {
-        const { rebakedAt } = await rebakeShell();
-        dispatch({ at: rebakedAt, type: "expired" });
+        await rebakeShell();
       } catch {
-        // The tag may well have been expired before the response died, so the
-        // copy promises nothing about what happened — it just says so.
         setRebakeFailed(true);
+        return;
       }
+      dispatch({ type: "fused" });
+      router.refresh();
     });
-  }, [rebakeLocked]);
+  }, [machinery, rebakeLocked, router]);
+
+  const handleToggle = useCallback(() => {
+    if (canFetch(state)) {
+      // Leaving the machinery view with an expiry unanswered: settle it on
+      // the way out — quietly finishing the round trip is exactly what real
+      // apps do — so the simple view never rests showing a render the cache
+      // refused to keep.
+      startFetch(() => {
+        dispatch({ type: "toggled" });
+        router.refresh();
+      });
+      return;
+    }
+    dispatch({ type: "toggled" });
+  }, [router, state]);
 
   const handleFetch = useCallback(() => {
     startFetch(() => {
@@ -144,7 +178,7 @@ export function RebakePanel({ currentId }: RebakePanelProps) {
           </div>
         </dl>
       </div>
-      <div className="flex flex-wrap items-center gap-3">
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
         <MarketingButton
           aria-disabled={rebakeLocked}
           className={REBAKE_LOCKED_LOOK}
@@ -154,19 +188,43 @@ export function RebakePanel({ currentId }: RebakePanelProps) {
           <StableSlot value={rebakeLabel} variants={REBAKE_LABELS} />
         </MarketingButton>
         {/*
-          Rendered in every phase, hidden from sight and from the a11y tree
-          when it doesn't apply, so the row always reserves its exact
-          footprint. `invisible` also takes it out of the tab order.
+          Only the machinery view splits the flow, so only it has a second
+          button. Within that view it renders in every phase — hidden from
+          sight and from the a11y tree when it doesn't apply — so the row
+          keeps its exact footprint. `invisible` also takes it out of the
+          tab order.
         */}
-        <MarketingButton
-          aria-hidden={!fetchable}
-          className={fetchable ? undefined : "invisible"}
-          disabled={!fetchable || isFetching}
-          onClick={handleFetch}
-          variant="outline"
-        >
-          <StableSlot value={fetchLabel} variants={FETCH_LABELS} />
-        </MarketingButton>
+        {machinery && (
+          <MarketingButton
+            aria-hidden={!fetchable}
+            className={fetchable ? undefined : "invisible"}
+            disabled={!fetchable || isFetching}
+            onClick={handleFetch}
+            variant="outline"
+          >
+            <StableSlot value={fetchLabel} variants={FETCH_LABELS} />
+          </MarketingButton>
+        )}
+        {/*
+          Disabled while either transition is in flight: a machinery press
+          resolving after the switch flipped off would strand the simple view
+          mid-gap, and the reducer's ignore-rule is only the fallback for
+          that — see rebake-state.test.ts.
+        */}
+        <div className="flex items-center gap-2 sm:ml-auto">
+          <Switch
+            checked={machinery}
+            disabled={isRebaking || isFetching}
+            id="rebake-slow-motion"
+            onCheckedChange={handleToggle}
+          />
+          <label
+            className="cursor-pointer font-mono text-muted-foreground text-xs/5"
+            htmlFor="rebake-slow-motion"
+          >
+            slow motion
+          </label>
+        </div>
       </div>
       {/*
         Its own live region rather than the one above: the caption sits below

--- a/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
@@ -33,7 +33,7 @@ const REBAKE_LOCKED_LOOK = cn(
 
 const IDLE_REBAKE_LABEL = "Re-bake this page";
 const REBAKE_LABELS = [IDLE_REBAKE_LABEL, "Re-baking…"];
-const FETCH_LABELS = ["Fetch what's actually cached", "Fetching…"];
+const FETCH_LABELS = ["Fetch what’s actually cached", "Fetching…"];
 
 /**
  * Renders `value` stacked on top of every string it could have been, so the

--- a/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
@@ -93,6 +93,8 @@ function StepMark({ n }: { n: string }) {
 interface RebakePanelProps {
   /** The fingerprint the server just rendered, whichever render that was. */
   currentId: string;
+  /** The instrument's reference bar — code drawer plus docs/source links. */
+  references?: React.ReactNode;
   /**
    * The server-rendered stamp, threaded through as a prop so this client
    * component can wrap it in the pending and landing treatments — the
@@ -108,7 +110,11 @@ interface RebakePanelProps {
  * switch doesn't add a second button — it splits the one button into the two
  * events it was always made of.
  */
-export function RebakePanel({ currentId, stamp }: RebakePanelProps) {
+export function RebakePanel({
+  currentId,
+  references,
+  stamp,
+}: RebakePanelProps) {
   const router = useRouter();
   const [state, dispatch] = useReducer(rebakeReducer, INITIAL_REBAKE_STATE);
   const [isRebaking, startRebake] = useTransition();
@@ -273,6 +279,7 @@ export function RebakePanel({ currentId, stamp }: RebakePanelProps) {
   return (
     <LivePanel
       deck={deck}
+      references={references}
       status={working ? "working" : "live"}
       viewControls={viewControls}
     >

--- a/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
@@ -215,7 +215,7 @@ export function RebakePanel({
   const machinery = state.mode === "machinery";
   const working = isRebaking || isFetching;
   const rebakeLocked = !canRebake(state) || isRebaking;
-  const fetchable = canFetch(state);
+  const fetchable = canFetch(state, currentId);
 
   const handleRebake = useCallback(() => {
     // Guards the same lock the button's `aria-disabled` shows, since that
@@ -225,10 +225,12 @@ export function RebakePanel({
     }
     setRebakeFailed(false);
     if (machinery) {
+      // `currentId` closes over the fingerprint on screen at press time —
+      // the ask stays dark until the private render has moved it.
       startRebake(async () => {
         try {
           const { rebakedAt } = await rebakeShell();
-          dispatch({ at: rebakedAt, type: "expired" });
+          dispatch({ at: rebakedAt, idAtExpiry: currentId, type: "expired" });
         } catch {
           // The tag may well have been expired before the response died, so
           // the copy promises nothing about what happened — it just says so.
@@ -250,7 +252,7 @@ export function RebakePanel({
       dispatch({ type: "fused" });
       router.refresh();
     });
-  }, [machinery, rebakeLocked, router]);
+  }, [currentId, machinery, rebakeLocked, router]);
 
   const handleFetch = useCallback(() => {
     startFetch(() => {
@@ -263,7 +265,9 @@ export function RebakePanel({
   }, [currentId, router]);
 
   const handleToggle = useCallback(() => {
-    const leavesGapOpen = canFetch(state);
+    // Any open gap owes a refresh on the way out — landed or not, so this
+    // checks the phase directly rather than the ask-button's stricter gate.
+    const leavesGapOpen = state.phase === "expired";
     // The flip itself stays OUT of the transition: it is client-owned state,
     // and inside one it would not paint until router.refresh() resolved —
     // the switch sat frozen for the whole round trip. Only the server sync

--- a/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
@@ -90,6 +90,93 @@ function StepMark({ n }: { n: string }) {
   );
 }
 
+interface DeckProps {
+  askLabel: string;
+  fetchable: boolean;
+  isFetching: boolean;
+  machinery: boolean;
+  onFetch: () => void;
+  onRebake: () => void;
+  rebakeLabel: string;
+  rebakeLocked: boolean;
+  revealed: boolean;
+}
+
+/**
+ * Actions in execution order; the deck may end in a result chip — output,
+ * never input. The view switch lives in the chrome, not here.
+ *
+ * The chip is the diagram's output node: the badge the platform's own logs
+ * file the refill under. A rule, not a per-request claim — whichever request
+ * refilled the entry (yours, a new tab's, another visitor's) is the one
+ * logged REVALIDATED.
+ */
+function Deck({
+  askLabel,
+  fetchable,
+  isFetching,
+  machinery,
+  onFetch,
+  onRebake,
+  rebakeLabel,
+  rebakeLocked,
+  revealed,
+}: DeckProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <MarketingButton
+        aria-disabled={rebakeLocked}
+        className={LOCKED_LOOK}
+        onClick={onRebake}
+        variant="outline"
+      >
+        {machinery ? <StepMark n="1" /> : null}
+        <StableSlot
+          value={rebakeLabel}
+          variants={machinery ? EXPIRE_LABELS : FUSED_LABELS}
+        />
+      </MarketingButton>
+      {machinery ? (
+        <>
+          <span
+            aria-hidden="true"
+            className="select-none font-mono text-muted-foreground/50"
+          >
+            →
+          </span>
+          <MarketingButton
+            disabled={!fetchable || isFetching}
+            onClick={onFetch}
+            variant="outline"
+          >
+            <StepMark n="2" />
+            <StableSlot value={askLabel} variants={ASK_LABELS} />
+          </MarketingButton>
+          {/* Reserved in every machinery phase so the reveal never moves the
+              row; `invisible` keeps it out of the a11y tree until it's true. */}
+          <span
+            aria-hidden={!revealed}
+            className={cn(
+              "flex items-center gap-3",
+              revealed ? undefined : "invisible"
+            )}
+          >
+            <span
+              aria-hidden="true"
+              className="select-none font-mono text-muted-foreground/50"
+            >
+              →
+            </span>
+            <span className="rounded-md border border-foreground/15 px-2 py-1 font-mono text-[0.65rem] text-muted-foreground uppercase tracking-wider">
+              revalidated · tag-based deletion
+            </span>
+          </span>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
 interface RebakePanelProps {
   /** The fingerprint the server just rendered, whichever render that was. */
   currentId: string;
@@ -216,40 +303,18 @@ export function RebakePanel({
   const askLabel = isFetching ? ASK_LABELS[1] : ASK_LABELS[0];
   const captionText = rebakeFailed ? REBAKE_FAILED_CAPTION : caption;
 
-  // Actions only — the view switch lives in the chrome, not here.
   const deck = (
-    <div className="flex flex-wrap items-center gap-3">
-      <MarketingButton
-        aria-disabled={rebakeLocked}
-        className={LOCKED_LOOK}
-        onClick={handleRebake}
-        variant="outline"
-      >
-        {machinery && <StepMark n="1" />}
-        <StableSlot
-          value={rebakeLabel}
-          variants={machinery ? EXPIRE_LABELS : FUSED_LABELS}
-        />
-      </MarketingButton>
-      {machinery && (
-        <>
-          <span
-            aria-hidden="true"
-            className="select-none font-mono text-muted-foreground/50"
-          >
-            →
-          </span>
-          <MarketingButton
-            disabled={!fetchable || isFetching}
-            onClick={handleFetch}
-            variant="outline"
-          >
-            <StepMark n="2" />
-            <StableSlot value={askLabel} variants={ASK_LABELS} />
-          </MarketingButton>
-        </>
-      )}
-    </div>
+    <Deck
+      askLabel={askLabel}
+      fetchable={fetchable}
+      isFetching={isFetching}
+      machinery={machinery}
+      onFetch={handleFetch}
+      onRebake={handleRebake}
+      rebakeLabel={rebakeLabel}
+      rebakeLocked={rebakeLocked}
+      revealed={machinery && state.phase === "refetched"}
+    />
   );
 
   /*

--- a/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-panel.tsx
@@ -3,8 +3,15 @@
 import { Switch } from "@repo/design-system/components/ui/switch";
 import { cn } from "@repo/design-system/lib/utils";
 import { useRouter } from "next/navigation";
-import { useCallback, useReducer, useState, useTransition } from "react";
+import {
+  useCallback,
+  useReducer,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import { MarketingButton } from "../../components/marketing-button";
+import { LivePanel } from "../live-panel";
 import { rebakeShell } from "./actions";
 import {
   CAPTION_VARIANTS,
@@ -21,21 +28,21 @@ import {
 } from "./rebake-state";
 
 // The outline variant's `disabled:` look, re-expressed for `aria-disabled` —
-// the re-bake button stays a real, focusable element while it's locked, so
-// keyboard and screen-reader users don't lose their place when the fetch
-// button appears beside it. See MarketingButton's `outline` variant.
+// the expire button stays a real, focusable element while it's locked, so
+// keyboard and screen-reader users don't lose their place when its lock
+// state flips. See MarketingButton's `outline` variant.
 //
 // The hover override earns its place: a natively disabled button is excluded
 // from `:hover` matching, but an `aria-disabled` one is still live, so the
 // variant's `hover:bg-muted` would light up a button that does nothing.
-const REBAKE_LOCKED_LOOK = cn(
+const LOCKED_LOOK = cn(
   "aria-disabled:bg-transparent aria-disabled:opacity-40",
   "aria-disabled:cursor-not-allowed aria-disabled:hover:bg-transparent"
 );
 
-const IDLE_REBAKE_LABEL = "Re-bake this page";
-const REBAKE_LABELS = [IDLE_REBAKE_LABEL, "Re-baking…"];
-const FETCH_LABELS = ["Fetch what’s actually cached", "Fetching…"];
+const FUSED_LABELS = ["Re-bake this page", "Re-baking…"];
+const EXPIRE_LABELS = ["Expire the entry", "Expiring…"];
+const ASK_LABELS = ["Ask for the page", "Asking…"];
 
 /**
  * Renders `value` stacked on top of every string it could have been, so the
@@ -71,29 +78,49 @@ function StableSlot({
   );
 }
 
+/** The mono step marker inside a deck button — real sequence, so real numbers. */
+function StepMark({ n }: { n: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="mr-2 select-none font-mono text-muted-foreground/60 text-xs"
+    >
+      {n}
+    </span>
+  );
+}
+
 interface RebakePanelProps {
   /** The fingerprint the server just rendered, whichever render that was. */
   currentId: string;
+  /**
+   * The server-rendered stamp, threaded through as a prop so this client
+   * component can wrap it in the pending and landing treatments — the
+   * server-component-as-prop composition exhibit one teaches.
+   */
+  stamp: React.ReactNode;
 }
 
 /**
- * One mechanism, two views, chosen by a switch. The simple view fuses the
- * expiry and the refill into one press — the flow real apps ship. The
- * machinery view gives the two events separate buttons, and the button you
- * can't press is doing as much teaching as the one you can.
- *
- * Every slot in here is sized for its tallest and widest state, because a
- * demo about cache timing is unreadable if the thing you are watching hops
- * down the page as it changes.
+ * Demo 02's instrument, in the house zones: display (the stamp, which dims
+ * while a round trip is out and flashes once when a new fingerprint lands),
+ * narration (provenance and caption, one block), and the deck. The slow-motion
+ * switch doesn't add a second button — it splits the one button into the two
+ * events it was always made of.
  */
-export function RebakePanel({ currentId }: RebakePanelProps) {
+export function RebakePanel({ currentId, stamp }: RebakePanelProps) {
   const router = useRouter();
   const [state, dispatch] = useReducer(rebakeReducer, INITIAL_REBAKE_STATE);
   const [isRebaking, startRebake] = useTransition();
   const [isFetching, startFetch] = useTransition();
   const [rebakeFailed, setRebakeFailed] = useState(false);
+  // The fingerprint the page arrived with. A remount of the display wrapper
+  // only counts as a landing once the id has moved off this — otherwise the
+  // first paint of the page would flash as though something had changed.
+  const initialIdRef = useRef(currentId);
 
   const machinery = state.mode === "machinery";
+  const working = isRebaking || isFetching;
   const rebakeLocked = !canRebake(state) || isRebaking;
   const fetchable = canFetch(state);
 
@@ -132,6 +159,16 @@ export function RebakePanel({ currentId }: RebakePanelProps) {
     });
   }, [machinery, rebakeLocked, router]);
 
+  const handleFetch = useCallback(() => {
+    startFetch(() => {
+      // Captured before the refresh lands, while the private render is still
+      // the thing on screen. Both updates sit in the same transition, so the
+      // panel keeps showing the expired state until the new bake arrives.
+      dispatch({ privateId: currentId, type: "refetched" });
+      router.refresh();
+    });
+  }, [currentId, router]);
+
   const handleToggle = useCallback(() => {
     const leavesGapOpen = canFetch(state);
     // The flip itself stays OUT of the transition: it is client-owned state,
@@ -152,107 +189,143 @@ export function RebakePanel({ currentId }: RebakePanelProps) {
     }
   }, [router, state]);
 
-  const handleFetch = useCallback(() => {
-    startFetch(() => {
-      // Captured before the refresh lands, while the private render is still
-      // the thing on screen. Both updates sit in the same transition, so the
-      // panel keeps showing the expired state until the new bake arrives.
-      dispatch({ privateId: currentId, type: "refetched" });
-      router.refresh();
-    });
-  }, [currentId, router]);
-
   // A fetch transition still flying after the mode flipped to simple is the
   // settling window: the owed refresh is out, and the stamp is still the
   // private render until it lands.
   const settling = isFetching && !machinery;
-  const { caption, detail, label } = settling
+  // During a fused press the reducer commits `fused` at the await boundary,
+  // before the refresh lands — so the readout is held at the pre-press state
+  // for the flight. The hook caption then arrives in the same paint as the
+  // new fingerprint, instead of congratulating a bake that isn't up yet.
+  const fusedInFlight = isRebaking && !machinery;
+  const {
+    caption,
+    detail,
+    label: statusLabel,
+  } = settling
     ? SETTLING_READOUT
-    : readout(state, currentId);
-  const rebakeLabel = isRebaking ? REBAKE_LABELS[1] : REBAKE_LABELS[0];
-  const fetchLabel = isFetching ? FETCH_LABELS[1] : FETCH_LABELS[0];
+    : readout(fusedInFlight ? INITIAL_REBAKE_STATE : state, currentId);
+  const rebakeLabels = machinery ? EXPIRE_LABELS : FUSED_LABELS;
+  const rebakeLabel = isRebaking ? rebakeLabels[1] : rebakeLabels[0];
+  const askLabel = isFetching ? ASK_LABELS[1] : ASK_LABELS[0];
   const captionText = rebakeFailed ? REBAKE_FAILED_CAPTION : caption;
 
-  return (
-    <div className="flex flex-col gap-3">
-      {/*
-        role="status" on a <dl> itself trips Biome's
-        noInteractiveElementToNoninteractiveRole rule, so the live region
-        wraps the definition list instead of landing on it directly.
-      */}
-      <div aria-live="polite" role="status">
-        <dl className="grid gap-1 font-mono text-muted-foreground text-sm/6">
-          <div className="flex gap-3">
-            <dt className="w-16 shrink-0 text-muted-foreground/60">{label}</dt>
-            <dd className="min-w-0 flex-1">
-              <StableSlot value={detail} variants={DETAIL_VARIANTS} />
-            </dd>
-          </div>
-        </dl>
-      </div>
-      <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
-        <MarketingButton
-          aria-disabled={rebakeLocked}
-          className={REBAKE_LOCKED_LOOK}
-          onClick={handleRebake}
-          variant="outline"
-        >
-          <StableSlot value={rebakeLabel} variants={REBAKE_LABELS} />
-        </MarketingButton>
-        {/*
-          Only the machinery view splits the flow, so only it has a second
-          button. Within that view it renders in every phase — hidden from
-          sight and from the a11y tree when it doesn't apply — so the row
-          keeps its exact footprint. `invisible` also takes it out of the
-          tab order.
-        */}
-        {machinery && (
+  // Actions only — the view switch lives in the chrome, not here.
+  const deck = (
+    <div className="flex flex-wrap items-center gap-3">
+      <MarketingButton
+        aria-disabled={rebakeLocked}
+        className={LOCKED_LOOK}
+        onClick={handleRebake}
+        variant="outline"
+      >
+        {machinery && <StepMark n="1" />}
+        <StableSlot
+          value={rebakeLabel}
+          variants={machinery ? EXPIRE_LABELS : FUSED_LABELS}
+        />
+      </MarketingButton>
+      {machinery && (
+        <>
+          <span
+            aria-hidden="true"
+            className="select-none font-mono text-muted-foreground/50"
+          >
+            →
+          </span>
           <MarketingButton
-            aria-hidden={!fetchable}
-            className={fetchable ? undefined : "invisible"}
             disabled={!fetchable || isFetching}
             onClick={handleFetch}
             variant="outline"
           >
-            <StableSlot value={fetchLabel} variants={FETCH_LABELS} />
+            <StepMark n="2" />
+            <StableSlot value={askLabel} variants={ASK_LABELS} />
           </MarketingButton>
-        )}
-        {/*
-          Disabled while either transition is in flight: a machinery press
-          resolving after the switch flipped off would strand the simple view
-          mid-gap, and the reducer's ignore-rule is only the fallback for
-          that — see rebake-state.test.ts.
-        */}
-        <div className="flex items-center gap-2 sm:ml-auto">
-          <Switch
-            checked={machinery}
-            disabled={isRebaking || isFetching}
-            id="rebake-slow-motion"
-            onCheckedChange={handleToggle}
-          />
-          <label
-            className="cursor-pointer font-mono text-muted-foreground text-xs/5"
-            htmlFor="rebake-slow-motion"
-          >
-            slow motion
-          </label>
-        </div>
-      </div>
-      {/*
-        Its own live region rather than the one above: the caption sits below
-        the buttons, so a single region can't span both without reordering
-        what a sighted reader sees. Two polite regions announce in DOM order —
-        the fact, then what to do about it.
-      */}
-      <p
-        aria-live="polite"
-        className={cn(
-          "font-mono text-xs/5",
-          rebakeFailed ? "text-destructive" : "text-muted-foreground"
-        )}
-      >
-        <StableSlot value={captionText} variants={CAPTION_VARIANTS} />
-      </p>
+        </>
+      )}
     </div>
+  );
+
+  /*
+    The view switch, in the corner every editor keeps its view controls.
+    Disabled while either transition is in flight: a machinery press
+    resolving after the switch flipped off would strand the simple view
+    mid-gap, and the reducer's ignore-rule is only the fallback for that —
+    see rebake-state.test.ts.
+  */
+  const viewControls = (
+    <div className="flex items-center gap-2.5">
+      <label
+        className="cursor-pointer select-none font-mono font-semibold text-[0.7rem] text-muted-foreground uppercase tracking-[0.2em]"
+        htmlFor="rebake-slow-motion"
+      >
+        slow motion
+      </label>
+      <Switch
+        checked={machinery}
+        disabled={working}
+        id="rebake-slow-motion"
+        onCheckedChange={handleToggle}
+      />
+    </div>
+  );
+
+  return (
+    <LivePanel
+      deck={deck}
+      status={working ? "working" : "live"}
+      viewControls={viewControls}
+    >
+      <div className="flex flex-col gap-5">
+        {/* The specimen: stamp plus provenance, one table. The stamp dims
+            and pulses while a round trip is out, and takes one amber wash
+            when a new fingerprint lands (key remount, .ht-land). The
+            provenance row shares the stamp's own grid so the two read as a
+            single instrument readout. role="status" on a <dl> itself trips
+            Biome's noInteractiveElementToNoninteractiveRole rule, so the
+            live region wraps the row instead. */}
+        <div>
+          <div
+            className={cn(
+              "transition-opacity duration-300",
+              working && "opacity-60 motion-safe:animate-pulse"
+            )}
+          >
+            <div
+              className={
+                currentId === initialIdRef.current ? undefined : "ht-land"
+              }
+              key={currentId}
+            >
+              {stamp}
+            </div>
+          </div>
+          <div aria-live="polite" className="mt-1" role="status">
+            <dl className="grid gap-1 font-mono text-muted-foreground text-sm/6">
+              <div className="flex gap-3">
+                <dt className="w-16 shrink-0 text-muted-foreground/60">
+                  {statusLabel}
+                </dt>
+                <dd className="min-w-0 flex-1">
+                  <StableSlot value={detail} variants={DETAIL_VARIANTS} />
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+        {/* The narration line — one teaching beat per phase, announced after
+            the provenance row (two polite regions, DOM order: the fact,
+            then what to do about it). */}
+        <p
+          aria-live="polite"
+          className={cn(
+            "font-mono text-xs/5",
+            rebakeFailed ? "text-destructive" : "text-muted-foreground"
+          )}
+        >
+          <StableSlot value={captionText} variants={CAPTION_VARIANTS} />
+        </p>
+      </div>
+    </LivePanel>
   );
 }

--- a/apps/web/app/[locale]/(playground)/shell/rebake-state.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-state.test.ts
@@ -19,25 +19,65 @@ function refetch(state: RebakeState, privateId = PRIVATE_ID): RebakeState {
   return rebakeReducer(state, { privateId, type: "refetched" });
 }
 
+function toggle(state: RebakeState): RebakeState {
+  return rebakeReducer(state, { type: "toggled" });
+}
+
+function fuse(state: RebakeState): RebakeState {
+  return rebakeReducer(state, { type: "fused" });
+}
+
+const MACHINERY_SERVED = toggle(INITIAL_REBAKE_STATE);
+
 describe("rebake state", () => {
-  test("you arrive looking at the shell everyone else gets", () => {
+  test("you arrive in the simple view, looking at the shell everyone gets", () => {
     const state = INITIAL_REBAKE_STATE;
-    expect(state).toEqual({ phase: "served" });
+    expect(state).toEqual({
+      hasCompletedCycle: false,
+      mode: "simple",
+      phase: "served",
+    });
     expect(canRebake(state)).toBe(true);
     expect(canFetch(state)).toBe(false);
   });
 
-  test("expiring records when, and locks the button until you answer it", () => {
-    const state = expire(INITIAL_REBAKE_STATE);
-    expect(state).toEqual({ expiredAt: EXPIRED_AT, phase: "expired" });
+  test("a fused press lands back where it started, with the cycle behind it", () => {
+    const state = fuse(INITIAL_REBAKE_STATE);
+    expect(state).toEqual({
+      hasCompletedCycle: true,
+      mode: "simple",
+      phase: "served",
+    });
+    expect(canRebake(state)).toBe(true);
+  });
+
+  test("the switch carries what you've seen into the machinery view", () => {
+    expect(MACHINERY_SERVED).toEqual({
+      hasCompletedCycle: false,
+      mode: "machinery",
+      phase: "served",
+    });
+    expect(toggle(fuse(INITIAL_REBAKE_STATE)).hasCompletedCycle).toBe(true);
+  });
+
+  test("in the machinery view, expiring records when and locks the button", () => {
+    const state = expire(MACHINERY_SERVED);
+    expect(state).toEqual({
+      expiredAt: EXPIRED_AT,
+      hasCompletedCycle: false,
+      mode: "machinery",
+      phase: "expired",
+    });
     expect(canRebake(state)).toBe(false);
     expect(canFetch(state)).toBe(true);
   });
 
-  test("fetching hands back the comparison and frees the button", () => {
-    const state = refetch(expire(INITIAL_REBAKE_STATE));
+  test("fetching hands back the comparison, frees the button, and counts as a cycle", () => {
+    const state = refetch(expire(MACHINERY_SERVED));
     expect(state).toEqual({
       expiredAt: EXPIRED_AT,
+      hasCompletedCycle: true,
+      mode: "machinery",
       phase: "refetched",
       privateId: PRIVATE_ID,
     });
@@ -45,19 +85,52 @@ describe("rebake state", () => {
     expect(canFetch(state)).toBe(false);
   });
 
+  test("switching off mid-gap settles into the simple view, cycle complete", () => {
+    // The panel pairs this transition with a router.refresh() — see
+    // handleToggle — so the simple view never rests on an unanswered expiry.
+    const state = toggle(expire(MACHINERY_SERVED));
+    expect(state).toEqual({
+      hasCompletedCycle: true,
+      mode: "simple",
+      phase: "served",
+    });
+  });
+
+  test("switching off after the reveal drops the comparison, which belongs to the machinery view", () => {
+    const state = toggle(refetch(expire(MACHINERY_SERVED)));
+    expect(state).toEqual({
+      hasCompletedCycle: true,
+      mode: "simple",
+      phase: "served",
+    });
+  });
+
   test("fetching without expiring first changes nothing", () => {
-    const state = INITIAL_REBAKE_STATE;
-    expect(refetch(state)).toBe(state);
+    expect(refetch(MACHINERY_SERVED)).toBe(MACHINERY_SERVED);
+    expect(refetch(INITIAL_REBAKE_STATE)).toBe(INITIAL_REBAKE_STATE);
   });
 
   test("fetching twice changes nothing the second time", () => {
-    const once = refetch(expire(INITIAL_REBAKE_STATE));
+    const once = refetch(expire(MACHINERY_SERVED));
     expect(refetch(once, "ffffffff")).toBe(once);
   });
 
   test("re-baking again clears the old comparison, which no longer has a subject", () => {
-    const state = expire(refetch(expire(INITIAL_REBAKE_STATE)), LATER);
-    expect(state).toEqual({ expiredAt: LATER, phase: "expired" });
+    const state = expire(refetch(expire(MACHINERY_SERVED)), LATER);
+    expect(state).toEqual({
+      expiredAt: LATER,
+      hasCompletedCycle: true,
+      mode: "machinery",
+      phase: "expired",
+    });
     expect(canFetch(state)).toBe(true);
+  });
+
+  test("the simple view ignores the machinery's actions", () => {
+    // A machinery press resolving after the switch flipped off must not strand
+    // the simple view in a phase it cannot display. The panel disables the
+    // switch while a press is in flight, so this is the belt to that brace.
+    expect(expire(INITIAL_REBAKE_STATE)).toBe(INITIAL_REBAKE_STATE);
+    expect(fuse(MACHINERY_SERVED)).toBe(MACHINERY_SERVED);
   });
 });

--- a/apps/web/app/[locale]/(playground)/shell/rebake-state.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-state.test.ts
@@ -9,7 +9,7 @@ import {
 
 const EXPIRED_AT = "2026-08-10T15:05:35.000Z";
 const LATER = "2026-08-10T15:09:00.000Z";
-const PRIVATE_ID = "1e472bda";
+const PRIVATE_ID = "1e472b";
 
 function expire(state: RebakeState, at = EXPIRED_AT): RebakeState {
   return rebakeReducer(state, { at, type: "expired" });
@@ -112,7 +112,7 @@ describe("rebake state", () => {
 
   test("fetching twice changes nothing the second time", () => {
     const once = refetch(expire(MACHINERY_SERVED));
-    expect(refetch(once, "ffffffff")).toBe(once);
+    expect(refetch(once, "ffffff")).toBe(once);
   });
 
   test("re-baking again clears the old comparison, which no longer has a subject", () => {

--- a/apps/web/app/[locale]/(playground)/shell/rebake-state.test.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-state.test.ts
@@ -9,10 +9,15 @@ import {
 
 const EXPIRED_AT = "2026-08-10T15:05:35.000Z";
 const LATER = "2026-08-10T15:09:00.000Z";
+const ID_AT_EXPIRY = "01dbake";
 const PRIVATE_ID = "1e472b";
 
 function expire(state: RebakeState, at = EXPIRED_AT): RebakeState {
-  return rebakeReducer(state, { at, type: "expired" });
+  return rebakeReducer(state, {
+    at,
+    idAtExpiry: ID_AT_EXPIRY,
+    type: "expired",
+  });
 }
 
 function refetch(state: RebakeState, privateId = PRIVATE_ID): RebakeState {
@@ -38,7 +43,7 @@ describe("rebake state", () => {
       phase: "served",
     });
     expect(canRebake(state)).toBe(true);
-    expect(canFetch(state)).toBe(false);
+    expect(canFetch(state, ID_AT_EXPIRY)).toBe(false);
   });
 
   test("a fused press lands back where it started, with the cycle behind it", () => {
@@ -65,11 +70,21 @@ describe("rebake state", () => {
     expect(state).toEqual({
       expiredAt: EXPIRED_AT,
       hasCompletedCycle: false,
+      idAtExpiry: ID_AT_EXPIRY,
       mode: "machinery",
       phase: "expired",
     });
     expect(canRebake(state)).toBe(false);
-    expect(canFetch(state)).toBe(true);
+  });
+
+  test("the ask stays dark until the private render has landed", () => {
+    // Clicking ask before the action's re-render arrives would capture the
+    // old shared fingerprint as the private one, and the comparison would
+    // claim a public bake had been yours alone. The gate: the fingerprint
+    // on screen must have moved off the one that was there at expiry.
+    const state = expire(MACHINERY_SERVED);
+    expect(canFetch(state, ID_AT_EXPIRY)).toBe(false);
+    expect(canFetch(state, PRIVATE_ID)).toBe(true);
   });
 
   test("fetching hands back the comparison, frees the button, and counts as a cycle", () => {
@@ -82,7 +97,7 @@ describe("rebake state", () => {
       privateId: PRIVATE_ID,
     });
     expect(canRebake(state)).toBe(true);
-    expect(canFetch(state)).toBe(false);
+    expect(canFetch(state, PRIVATE_ID)).toBe(false);
   });
 
   test("switching off mid-gap settles into the simple view, cycle complete", () => {
@@ -120,10 +135,11 @@ describe("rebake state", () => {
     expect(state).toEqual({
       expiredAt: LATER,
       hasCompletedCycle: true,
+      idAtExpiry: ID_AT_EXPIRY,
       mode: "machinery",
       phase: "expired",
     });
-    expect(canFetch(state)).toBe(true);
+    expect(canFetch(state, PRIVATE_ID)).toBe(true);
   });
 
   test("the simple view ignores the machinery's actions", () => {

--- a/apps/web/app/[locale]/(playground)/shell/rebake-state.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-state.ts
@@ -24,6 +24,8 @@ export type RebakeState =
   | {
       expiredAt: string;
       hasCompletedCycle: boolean;
+      /** The fingerprint that was on screen when the press happened. */
+      idAtExpiry: string;
       mode: "machinery";
       phase: "expired";
     }
@@ -36,7 +38,7 @@ export type RebakeState =
     };
 
 export type RebakeAction =
-  | { at: string; type: "expired" }
+  | { at: string; idAtExpiry: string; type: "expired" }
   | { privateId: string; type: "refetched" }
   | { type: "fused" }
   | { type: "toggled" };
@@ -88,6 +90,7 @@ export function rebakeReducer(
     return {
       expiredAt: action.at,
       hasCompletedCycle: state.hasCompletedCycle,
+      idAtExpiry: action.idAtExpiry,
       mode: "machinery",
       phase: "expired",
     };
@@ -110,10 +113,15 @@ export function canRebake(state: RebakeState): boolean {
 }
 
 /**
- * The fetch button exists only when there is something to fetch. The panel
- * also uses this to know that flipping the switch off must settle the gap
- * with a refresh.
+ * The ask button lights only when there is something to fetch AND the
+ * private render has landed — the fingerprint on screen has moved off the
+ * one that was there at expiry. Asking earlier would capture the old shared
+ * fingerprint as the private one, and the comparison would claim a public
+ * bake had been yours alone.
+ *
+ * (The settle-on-toggle-off path checks `phase === "expired"` directly: any
+ * open gap owes a refresh, landed or not.)
  */
-export function canFetch(state: RebakeState): boolean {
-  return state.phase === "expired";
+export function canFetch(state: RebakeState, currentId: string): boolean {
+  return state.phase === "expired" && state.idAtExpiry !== currentId;
 }

--- a/apps/web/app/[locale]/(playground)/shell/rebake-state.ts
+++ b/apps/web/app/[locale]/(playground)/shell/rebake-state.ts
@@ -1,22 +1,51 @@
 /**
- * Where the visitor stands in the two-phase re-bake, which is the whole lesson
- * of this demo: expiring a cache entry and refilling it are separate events,
- * and the bake you are shown in between was cached for nobody.
+ * Where the visitor stands in the re-bake demo, which runs in two views:
  *
- * `served`    — you are looking at the shell every visitor gets.
- * `expired`   — you pressed the button. The hash on screen is a private render.
- * `refetched` — you asked for the real one, and can now compare the two.
+ * `simple`    — one button, and a press runs the whole round trip (the
+ *               updateTag action, then a refresh) fused into one event. This
+ *               is the flow real apps ship, and the reason the belief this
+ *               exhibit answers feels true.
+ * `machinery` — the same mechanism with the fusion switched off: expiring and
+ *               refilling get separate buttons, and the gap between them is
+ *               allowed to sit on screen.
+ *
+ * The invariant the types encode: the simple view only ever rests in `served`.
+ * An unanswered expiry can exist only where it is being narrated — flipping
+ * the switch off mid-gap settles it (the panel pairs that toggle with a
+ * refresh), so the stamp never quietly shows a render the cache refused.
+ *
+ * `hasCompletedCycle` remembers that at least one full expire-and-refill has
+ * happened, in either view — it is what turns the simple caption from an
+ * invitation into the hook for the switch.
  */
 export type RebakeState =
-  | { phase: "served" }
-  | { expiredAt: string; phase: "expired" }
-  | { expiredAt: string; phase: "refetched"; privateId: string };
+  | { hasCompletedCycle: boolean; mode: "simple"; phase: "served" }
+  | { hasCompletedCycle: boolean; mode: "machinery"; phase: "served" }
+  | {
+      expiredAt: string;
+      hasCompletedCycle: boolean;
+      mode: "machinery";
+      phase: "expired";
+    }
+  | {
+      expiredAt: string;
+      hasCompletedCycle: boolean;
+      mode: "machinery";
+      phase: "refetched";
+      privateId: string;
+    };
 
 export type RebakeAction =
   | { at: string; type: "expired" }
-  | { privateId: string; type: "refetched" };
+  | { privateId: string; type: "refetched" }
+  | { type: "fused" }
+  | { type: "toggled" };
 
-export const INITIAL_REBAKE_STATE: RebakeState = { phase: "served" };
+export const INITIAL_REBAKE_STATE: RebakeState = {
+  hasCompletedCycle: false,
+  mode: "simple",
+  phase: "served",
+};
 
 /**
  * `privateId` is captured on the *fetch*, not on the expiry. At expiry time the
@@ -28,16 +57,48 @@ export function rebakeReducer(
   state: RebakeState,
   action: RebakeAction
 ): RebakeState {
-  if (action.type === "expired") {
-    // Always legal. Re-baking after a fetch drops the previous comparison,
-    // which has just lost its subject.
-    return { expiredAt: action.at, phase: "expired" };
+  if (action.type === "fused") {
+    if (state.mode !== "simple") {
+      return state;
+    }
+    return { hasCompletedCycle: true, mode: "simple", phase: "served" };
   }
-  if (state.phase !== "expired") {
+  if (action.type === "toggled") {
+    if (state.mode === "simple") {
+      return {
+        hasCompletedCycle: state.hasCompletedCycle,
+        mode: "machinery",
+        phase: "served",
+      };
+    }
+    return {
+      // Leaving mid-gap counts as a completed cycle: the panel answers the
+      // expiry on the way out, and the visitor watched both halves happen.
+      hasCompletedCycle: state.hasCompletedCycle || state.phase === "expired",
+      mode: "simple",
+      phase: "served",
+    };
+  }
+  if (action.type === "expired") {
+    if (state.mode !== "machinery") {
+      return state;
+    }
+    // Always legal within the machinery view. Re-baking after a fetch drops
+    // the previous comparison, which has just lost its subject.
+    return {
+      expiredAt: action.at,
+      hasCompletedCycle: state.hasCompletedCycle,
+      mode: "machinery",
+      phase: "expired",
+    };
+  }
+  if (state.mode !== "machinery" || state.phase !== "expired") {
     return state;
   }
   return {
     expiredAt: state.expiredAt,
+    hasCompletedCycle: true,
+    mode: "machinery",
     phase: "refetched",
     privateId: action.privateId,
   };
@@ -48,7 +109,11 @@ export function canRebake(state: RebakeState): boolean {
   return state.phase !== "expired";
 }
 
-/** The fetch button exists only when there is something to fetch. */
+/**
+ * The fetch button exists only when there is something to fetch. The panel
+ * also uses this to know that flipping the switch off must settle the gap
+ * with a refresh.
+ */
 export function canFetch(state: RebakeState): boolean {
   return state.phase === "expired";
 }

--- a/apps/web/app/[locale]/(playground)/shell/source.ts
+++ b/apps/web/app/[locale]/(playground)/shell/source.ts
@@ -6,7 +6,7 @@ export async function getBake() {
   cacheLife("days");
   return {
     bakedAt: new Date().toISOString(),
-    id: crypto.randomUUID().slice(0, 8), // the fingerprint
+    id: crypto.randomUUID().slice(0, 6), // the fingerprint — and a CSS color
   };
 }
 

--- a/apps/web/app/[locale]/(playground)/shell/source.ts
+++ b/apps/web/app/[locale]/(playground)/shell/source.ts
@@ -19,4 +19,8 @@ export async function rebakeShell() {
   // this response was cached for nobody. The next request makes the real one.
   return { rebakedAt: new Date().toISOString() };
 }
+
+// rebake-panel.tsx — button two, the "ask"
+router.refresh(); // no cache API anywhere — one more request for the page,
+                  // indistinguishable from a new tab or another visitor
 `;

--- a/apps/web/app/[locale]/components/contents-nav.tsx
+++ b/apps/web/app/[locale]/components/contents-nav.tsx
@@ -1,0 +1,71 @@
+import { Container } from "./container";
+
+const CHAPTERS: readonly { href: string; label: string; n: string }[] = [
+  { href: "#demo-01", label: "The boundary", n: "01" },
+  { href: "#demo-02", label: "The cache", n: "02" },
+  { href: "#demo-03", label: "The stream", n: "03" },
+  { href: "#demo-04", label: "The mutation", n: "04" },
+  { href: "#demo-05", label: "The image", n: "05" },
+];
+
+/**
+ * The contents row, slim enough to pin. It sits where the hero's contents
+ * grid used to and sticks to the viewport top while the visitor is among
+ * the exhibits — its parent in page.tsx ends after demo 05, so sticky
+ * positioning releases it there and the roadmap onward scrolls nav-free.
+ * Zero JavaScript: it is simply there, then pinned, then gone.
+ *
+ * One horizontal row at every viewport; on phones it scrolls sideways
+ * instead of wrapping, so the pinned cost stays one line tall. Exhibit
+ * sections carry `scroll-mt-16`, which clears the bar on anchor jumps.
+ */
+export function ContentsNav() {
+  return (
+    <nav
+      aria-label="Contents"
+      className="sticky top-0 z-40 border-foreground/10 border-y bg-background/90 backdrop-blur-sm"
+    >
+      <Container>
+        {/* The same rail grid the exhibits sit in: the label drifts into the
+            gutter the ghost numerals used to hold (right-aligned toward the
+            content, like they were), and the first link takes the content
+            column's left edge — links are the row; the label is margin
+            furniture. The nav keeps its accessible name on mobile, where the
+            rail collapses and the label with it. */}
+        <div className="lg:grid lg:grid-cols-[7rem_minmax(0,1fr)] lg:items-baseline lg:gap-x-12">
+          <div className="hidden py-3.5 text-right lg:block">
+            <span className="font-mono font-semibold text-[0.7rem] text-muted-foreground uppercase tracking-[0.2em]">
+              contents
+            </span>
+          </div>
+          <div className="flex max-w-3xl items-baseline gap-x-7 overflow-x-auto whitespace-nowrap py-3.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            {/* Desktop distributes the links across the full row — the same
+              rhythm the hero's five-column grid had — instead of leaving a
+              left-aligned stub with dead space to its right. The mobile
+              scroll-row keeps plain gaps: justify-between is a no-op once
+              the content overflows. */}
+            <ol className="flex flex-1 items-baseline gap-x-7 md:justify-between">
+              {CHAPTERS.map((chapter) => (
+                <li className="shrink-0" key={chapter.n}>
+                  <a
+                    className="group flex items-baseline gap-2 text-foreground/70 transition-colors hover:text-foreground"
+                    href={chapter.href}
+                  >
+                    <span className="font-mono text-muted-foreground text-xs tabular-nums transition-colors group-hover:text-ht-cyan-700 dark:group-hover:text-ht-cyan-300">
+                      {chapter.n}
+                    </span>
+                    {/* The rule draws itself in on hover — the same movement
+                      the reveals use, at link scale. */}
+                    <span className="font-display text-sm tracking-tight underline decoration-1 decoration-transparent underline-offset-[6px] transition-[text-decoration-color] duration-300 group-hover:decoration-ht-cyan-700/70 dark:group-hover:decoration-ht-cyan-300/70">
+                      {chapter.label}
+                    </span>
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      </Container>
+    </nav>
+  );
+}

--- a/apps/web/app/[locale]/components/faqs.tsx
+++ b/apps/web/app/[locale]/components/faqs.tsx
@@ -16,7 +16,7 @@ const faqs: {
   {
     answer:
       "The playground is free. Completely, permanently, no-asterisk free. The paid thing is coaching: small cohorts where you build production apps with me on exactly these topics, AI workflow included. The page teaches; the cohort makes it stick.",
-    meta: "See? We told you what we’re selling. Most landing pages hide that part.",
+    meta: "Now you know what’s being sold. Weigh the rest of the page against that.",
     question: "Is this free?",
   },
   {

--- a/apps/web/app/[locale]/components/faqs.tsx
+++ b/apps/web/app/[locale]/components/faqs.tsx
@@ -4,7 +4,7 @@ import { MetaAside } from "./meta-aside";
 import { Heading, Subheading } from "./text";
 
 const faqs: {
-  answer: string;
+  answer: React.ReactNode;
   meta?: string;
   question: string;
 }[] = [
@@ -35,8 +35,31 @@ const faqs: {
     question: "Why not just read the docs?",
   },
   {
-    answer:
-      "In public, with AI. The repo is on GitHub. The building happens in Conductor, with Claude Code doing the typing, and the process — prompts, checkpoints, wrong turns included — is being published alongside via Entire.io. This site is its own biggest demo.",
+    answer: (
+      <>
+        In public, with AI. The{" "}
+        <a
+          className="underline decoration-ht-cyan-700/40 underline-offset-2 transition-colors hover:decoration-ht-cyan-700"
+          href="https://github.com/hasToggle/hasToggle.dev"
+          rel="noreferrer"
+          target="_blank"
+        >
+          repo is on GitHub
+        </a>
+        . The building happens in Conductor, with Claude Code doing the typing,
+        and Entire.io publishes the process — prompts, checkpoints, wrong turns
+        included — to{" "}
+        <a
+          className="underline decoration-ht-cyan-700/40 underline-offset-2 transition-colors hover:decoration-ht-cyan-700"
+          href="https://github.com/hasToggle/hasToggle.dev-checkpoints"
+          rel="noreferrer"
+          target="_blank"
+        >
+          a second public repo
+        </a>
+        . This site is its own biggest demo.
+      </>
+    ),
     meta: "The AI writes the code. Someone still has to decide what ships, and that part hasn’t been automated.",
     question: "How is this site built?",
   },
@@ -53,7 +76,7 @@ function FaqItem({
   meta,
 }: {
   question: string;
-  answer: string;
+  answer: React.ReactNode;
   meta?: string;
 }) {
   return (

--- a/apps/web/app/[locale]/components/faqs.tsx
+++ b/apps/web/app/[locale]/components/faqs.tsx
@@ -32,12 +32,12 @@ const faqs: {
   {
     answer:
       "In public, with AI. The repo is on GitHub. The building happens in Conductor, with Claude Code doing the typing, and the process — prompts, checkpoints, wrong turns included — is being published alongside via Entire.io. This site is its own biggest demo.",
-    meta: "The AI writes the code. The judgment about what ships stays human. That division of labor is the actual curriculum.",
+    meta: "The AI writes the code. Someone still has to decide what ships, and that part hasn’t been automated.",
     question: "How is this site built?",
   },
   {
     answer:
-      "One new exhibit and its write-up: what it shows, why it matters, when to reach for it. Five minutes, no filler, and unsubscribing stays one click away.",
+      "One new exhibit and the write-up that goes with it. Five minutes, no filler, and nothing you have to read on a schedule.",
     question: "What lands in my inbox on Monday?",
   },
 ];
@@ -78,7 +78,7 @@ export function FrequentlyAskedQuestions() {
             as="h2"
             className="mt-3 text-balance text-4xl sm:text-5xl md:text-6xl"
           >
-            Your questions answered.
+            Before you poke anything.
           </Heading>
         </div>
 

--- a/apps/web/app/[locale]/components/faqs.tsx
+++ b/apps/web/app/[locale]/components/faqs.tsx
@@ -16,7 +16,7 @@ const faqs: {
   {
     answer:
       "The playground is free. Completely, permanently, no-asterisk free. The paid thing is coaching: small cohorts where you build production apps with me on exactly these topics, AI workflow included. The page teaches; the cohort makes it stick.",
-    meta: "Now you know what’s being sold. Weigh the rest of the page against that.",
+    meta: "The playground doesn’t get better if you buy the cohort. It’s the same page either way.",
     question: "Is this free?",
   },
   {

--- a/apps/web/app/[locale]/components/faqs.tsx
+++ b/apps/web/app/[locale]/components/faqs.tsx
@@ -15,6 +15,11 @@ const faqs: {
   },
   {
     answer:
+      "No. Vercel hasn’t endorsed this site, and nobody on the Next.js team sees an exhibit before it ships. The mistakes are ours, and so is the freedom to say which parts are confusing.",
+    question: "Is this official?",
+  },
+  {
+    answer:
       "The playground is free. Completely, permanently, no-asterisk free. The paid thing is coaching: small cohorts where you build production apps with me on exactly these topics, AI workflow included. The page teaches; the cohort makes it stick.",
     meta: "The playground doesn’t get better if you buy the cohort. It’s the same page either way.",
     question: "Is this free?",

--- a/apps/web/app/[locale]/components/footer.tsx
+++ b/apps/web/app/[locale]/components/footer.tsx
@@ -42,6 +42,14 @@ function Sitemap() {
   );
 }
 
+function SocialIconGitHub(props: React.ComponentPropsWithoutRef<"svg">) {
+  return (
+    <svg aria-hidden="true" fill="currentColor" viewBox="0 0 16 16" {...props}>
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  );
+}
+
 function SocialIconX(props: React.ComponentPropsWithoutRef<"svg">) {
   return (
     <svg aria-hidden="true" fill="currentColor" viewBox="0 0 16 16" {...props}>
@@ -74,6 +82,14 @@ function SocialIconLinkedIn(props: React.ComponentPropsWithoutRef<"svg">) {
 function SocialLinks() {
   return (
     <>
+      <Link
+        aria-label="Read the hasToggle source on GitHub"
+        className="text-foreground hover:text-foreground/75"
+        href="https://github.com/hasToggle/hasToggle.dev"
+        target="_blank"
+      >
+        <SocialIconGitHub className="size-4" />
+      </Link>
       <Link
         aria-label="Visit Eric on YouTube"
         className="text-foreground hover:text-foreground/75"

--- a/apps/web/app/[locale]/components/footer.tsx
+++ b/apps/web/app/[locale]/components/footer.tsx
@@ -154,6 +154,10 @@ export function Footer() {
             </div>
           </PlusGridRow>
         </PlusGrid>
+        <div className="pb-10 text-center text-muted-foreground/80 text-xs/5">
+          hasToggle is an independent project, not affiliated with or endorsed
+          by Vercel. Next.js and Vercel are trademarks of Vercel, Inc.
+        </div>
       </Container>
     </footer>
   );

--- a/apps/web/app/[locale]/components/footer.tsx
+++ b/apps/web/app/[locale]/components/footer.tsx
@@ -144,8 +144,7 @@ export function Footer() {
             </div>
             <div>
               <div className="py-3 text-center text-muted-foreground text-sm/6">
-                Come back Monday — there&apos;ll be something new to poke.
-                Welcome to hasToggle.
+                Come back Monday. There&apos;ll be something new to press.
               </div>
             </div>
             <div className="flex">

--- a/apps/web/app/[locale]/components/footer.tsx
+++ b/apps/web/app/[locale]/components/footer.tsx
@@ -144,7 +144,7 @@ export function Footer() {
             </div>
             <div>
               <div className="py-3 text-center text-muted-foreground text-sm/6">
-                Come back Monday. There&apos;ll be something new to press.
+                Come back Monday. There&apos;ll be something new to poke.
               </div>
             </div>
             <div className="flex">

--- a/apps/web/app/[locale]/components/footer.tsx
+++ b/apps/web/app/[locale]/components/footer.tsx
@@ -144,7 +144,7 @@ export function Footer() {
             </div>
             <div>
               <div className="py-3 text-center text-muted-foreground text-sm/6">
-                Come back Monday. There&apos;ll be something new to poke.
+                Come back Monday. There&rsquo;ll be something new to poke.
               </div>
             </div>
             <div className="flex">

--- a/apps/web/app/[locale]/components/hero-asterisk.tsx
+++ b/apps/web/app/[locale]/components/hero-asterisk.tsx
@@ -5,6 +5,7 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@repo/design-system/components/ui/hover-card";
+import { HeroFootnoteBody } from "./hero-footnote";
 
 // Kept as its own client component so the Radix HoverCard trigger isn't passed
 // as a Server Component child into the hero's <h1>. Doing so caused a React 19 /
@@ -23,12 +24,7 @@ export function HeroAsterisk() {
         side="bottom"
       >
         <p className="font-mono text-ht-cyan-900/80 text-sm/6 dark:text-ht-cyan-300/90">
-          <span aria-hidden="true" className="select-none opacity-70">
-            *&nbsp;
-          </span>
-          Or don&apos;t take it on faith. Every panel below answers back when
-          you press it, and every one links to the code that did it. Skepticism
-          is the correct instinct.
+          <HeroFootnoteBody />
         </p>
       </HoverCardContent>
     </HoverCard>

--- a/apps/web/app/[locale]/components/hero-asterisk.tsx
+++ b/apps/web/app/[locale]/components/hero-asterisk.tsx
@@ -26,9 +26,9 @@ export function HeroAsterisk() {
           <span aria-hidden="true" className="select-none opacity-70">
             *&nbsp;
           </span>
-          Or better: run it yourself. Everything below answers back when you
-          press it. And view source whenever you like — skepticism is the
-          correct instinct.
+          Or don&apos;t take it on faith. Every panel below answers back when
+          you press it, and every one links to the code that did it. Skepticism
+          is the correct instinct.
         </p>
       </HoverCardContent>
     </HoverCard>

--- a/apps/web/app/[locale]/components/hero-footnote.tsx
+++ b/apps/web/app/[locale]/components/hero-footnote.tsx
@@ -1,0 +1,21 @@
+/**
+ * The body of the hero asterisk's footnote: the marker and the text, with no
+ * wrapper of its own.
+ *
+ * It renders twice — in the desktop hover card (`hero-asterisk.tsx`) and in the
+ * mobile block below the contents list (`hero.tsx`) — but the two wrappers
+ * differ, so only the shared inside lives here. It was duplicated verbatim
+ * until nothing but hand-checking kept the copies in sync.
+ */
+export function HeroFootnoteBody() {
+  return (
+    <>
+      <span aria-hidden="true" className="select-none opacity-70">
+        *&nbsp;
+      </span>
+      You&apos;ve opened a &ldquo;live demo&rdquo; that turned out to be an
+      animated GIF. So have we. The demos below answer back, and the code that
+      made them is one click down.
+    </>
+  );
+}

--- a/apps/web/app/[locale]/components/hero-footnote.tsx
+++ b/apps/web/app/[locale]/components/hero-footnote.tsx
@@ -13,7 +13,7 @@ export function HeroFootnoteBody() {
       <span aria-hidden="true" className="select-none opacity-70">
         *&nbsp;
       </span>
-      You&apos;ve opened a &ldquo;live demo&rdquo; that turned out to be an
+      You&rsquo;ve opened a &ldquo;live demo&rdquo; that turned out to be an
       animated GIF. So have we. The demos below answer back, and the code that
       made them is one click down.
     </>

--- a/apps/web/app/[locale]/components/hero-footnote.tsx
+++ b/apps/web/app/[locale]/components/hero-footnote.tsx
@@ -13,9 +13,8 @@ export function HeroFootnoteBody() {
       <span aria-hidden="true" className="select-none opacity-70">
         *&nbsp;
       </span>
-      You&rsquo;ve opened a &ldquo;live demo&rdquo; that turned out to be an
-      animated GIF. So have we. The demos below answer back, and the code that
-      made them is one click down.
+      everything below runs · the source is in every panel · even the prompts
+      are public
     </>
   );
 }

--- a/apps/web/app/[locale]/components/hero.tsx
+++ b/apps/web/app/[locale]/components/hero.tsx
@@ -25,7 +25,7 @@ export function Hero() {
             deliberate, short enough that nobody waits on it. */}
         <div className="pt-20 pb-16 sm:pt-28 sm:pb-20 md:pt-36 md:pb-24">
           <p className="ht-enter mb-8 max-w-2xl font-medium text-foreground/70 text-lg/7 sm:text-xl/8">
-            The live playground for Next.js and Vercel.
+            The unofficial live playground for Next.js and Vercel.
           </p>
           <h1
             className="ht-enter max-w-4xl font-display font-medium text-6xl/[0.95] text-foreground tracking-tight sm:text-7xl/[0.95] md:text-8xl/[0.95]"

--- a/apps/web/app/[locale]/components/hero.tsx
+++ b/apps/web/app/[locale]/components/hero.tsx
@@ -7,14 +7,6 @@ import { MarketingButton } from "./marketing-button";
 import { MetaAside } from "./meta-aside";
 import { Navbar } from "./navbar";
 
-const CHAPTERS: readonly { href: string; label: string; n: string }[] = [
-  { href: "#demo-01", label: "The boundary", n: "01" },
-  { href: "#demo-02", label: "The shell", n: "02" },
-  { href: "#demo-03", label: "The stream", n: "03" },
-  { href: "#demo-04", label: "The mutation", n: "04" },
-  { href: "#demo-05", label: "The image", n: "05" },
-];
-
 export function Hero() {
   return (
     <div className="relative">
@@ -57,42 +49,16 @@ export function Hero() {
           </div>
         </div>
 
-        <Separator className="bg-foreground/10" />
-
-        <section aria-labelledby="contents-heading" className="py-10 md:py-12">
-          <h2
-            className="mb-6 font-mono font-semibold text-[0.7rem] text-muted-foreground uppercase tracking-[0.2em]"
-            id="contents-heading"
-          >
-            Contents
-          </h2>
-          <ol className="grid grid-cols-1 gap-x-8 gap-y-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
-            {CHAPTERS.map((chapter) => (
-              <li key={chapter.n}>
-                <a
-                  className="group flex items-baseline gap-3 text-foreground/70 transition-colors hover:text-foreground"
-                  href={chapter.href}
-                >
-                  <span className="font-mono text-muted-foreground text-sm tabular-nums transition-colors group-hover:text-ht-cyan-700 dark:group-hover:text-ht-cyan-300">
-                    {chapter.n}
-                  </span>
-                  {/* The rule draws itself in on hover rather than appearing:
-                      the same movement the reveals use, at link scale. */}
-                  <span className="font-display text-base tracking-tight underline decoration-1 decoration-transparent underline-offset-[6px] transition-[text-decoration-color] duration-300 group-hover:decoration-ht-cyan-700/70 dark:group-hover:decoration-ht-cyan-300/70">
-                    {chapter.label}
-                  </span>
-                </a>
-              </li>
-            ))}
-          </ol>
-        </section>
-
-        <Separator className="bg-foreground/10" />
-
-        <div className="pt-8 pb-16 md:hidden" id="hero-footnote-1">
-          <MetaAside noMarker variant="block">
-            <HeroFootnoteBody />
-          </MetaAside>
+        {/* The contents row lives outside the hero now (contents-nav.tsx),
+            so it can pin to the viewport — sticky is bounded by its parent,
+            and inside this container it would stick for zero pixels. */}
+        <div className="md:hidden" id="hero-footnote-1">
+          <Separator className="bg-foreground/10" />
+          <div className="pt-8 pb-16">
+            <MetaAside noMarker variant="block">
+              <HeroFootnoteBody />
+            </MetaAside>
+          </div>
         </div>
       </Container>
     </div>

--- a/apps/web/app/[locale]/components/hero.tsx
+++ b/apps/web/app/[locale]/components/hero.tsx
@@ -2,6 +2,7 @@ import { Separator } from "@repo/design-system/components/ui/separator";
 import { HeroReadout } from "../(playground)/hero-readout";
 import { Container } from "./container";
 import { HeroAsterisk } from "./hero-asterisk";
+import { HeroFootnoteBody } from "./hero-footnote";
 import { MarketingButton } from "./marketing-button";
 import { MetaAside } from "./meta-aside";
 import { Navbar } from "./navbar";
@@ -90,12 +91,7 @@ export function Hero() {
 
         <div className="pt-8 pb-16 md:hidden" id="hero-footnote-1">
           <MetaAside noMarker variant="block">
-            <span aria-hidden="true" className="select-none opacity-70">
-              *&nbsp;
-            </span>
-            Or don&apos;t take it on faith. Every panel below answers back when
-            you press it, and every one links to the code that did it.
-            Skepticism is the correct instinct.
+            <HeroFootnoteBody />
           </MetaAside>
         </div>
       </Container>

--- a/apps/web/app/[locale]/components/hero.tsx
+++ b/apps/web/app/[locale]/components/hero.tsx
@@ -19,24 +19,39 @@ export function Hero() {
     <div className="relative">
       <Container className="relative">
         <Navbar variant="light" />
+        {/* The load sequence states the thesis one line at a time. Delays are
+            small and the whole run is under a second — long enough to read as
+            deliberate, short enough that nobody waits on it. */}
         <div className="pt-20 pb-16 sm:pt-28 sm:pb-20 md:pt-36 md:pb-24">
-          <p className="mb-8 max-w-2xl font-medium text-foreground/70 text-lg/7 sm:text-xl/8">
+          <p className="ht-enter mb-8 max-w-2xl font-medium text-foreground/70 text-lg/7 sm:text-xl/8">
             The live playground for Next.js and Vercel.
           </p>
-          <h1 className="max-w-4xl font-display font-medium text-6xl/[0.95] text-foreground tracking-tight sm:text-7xl/[0.95] md:text-8xl/[0.95]">
+          <h1
+            className="ht-enter max-w-4xl font-display font-medium text-6xl/[0.95] text-foreground tracking-tight sm:text-7xl/[0.95] md:text-8xl/[0.95]"
+            style={{ "--ht-delay": "80ms" } as React.CSSProperties}
+          >
             Watch it run.
             <HeroAsterisk />
           </h1>
-          <p className="mt-8 max-w-xl font-medium text-muted-foreground text-xl/8 sm:text-2xl/9">
+          <p
+            className="ht-enter mt-8 max-w-xl font-medium text-muted-foreground text-xl/8 sm:text-2xl/9"
+            style={{ "--ht-delay": "180ms" } as React.CSSProperties}
+          >
             For developers who learn by poking things.
           </p>
-          <div className="mt-12 flex flex-col items-start gap-x-8 gap-y-4 sm:flex-row sm:flex-wrap sm:items-center">
+          <div
+            className="ht-enter mt-12 flex flex-col items-start gap-x-8 gap-y-4 sm:flex-row sm:flex-wrap sm:items-center"
+            style={{ "--ht-delay": "280ms" } as React.CSSProperties}
+          >
             <MarketingButton href="#demo-01">Start poking</MarketingButton>
             <MetaAside className="sm:max-w-xs">
               Nothing on this page is a mockup. We checked twice.
             </MetaAside>
           </div>
-          <div className="mt-12 max-w-xl">
+          <div
+            className="ht-enter mt-12 max-w-xl"
+            style={{ "--ht-delay": "380ms" } as React.CSSProperties}
+          >
             <HeroReadout />
           </div>
         </div>
@@ -60,7 +75,9 @@ export function Hero() {
                   <span className="font-mono text-muted-foreground text-sm tabular-nums transition-colors group-hover:text-ht-cyan-700 dark:group-hover:text-ht-cyan-300">
                     {chapter.n}
                   </span>
-                  <span className="font-display text-base tracking-tight">
+                  {/* The rule draws itself in on hover rather than appearing:
+                      the same movement the reveals use, at link scale. */}
+                  <span className="font-display text-base tracking-tight underline decoration-1 decoration-transparent underline-offset-[6px] transition-[text-decoration-color] duration-300 group-hover:decoration-ht-cyan-700/70 dark:group-hover:decoration-ht-cyan-300/70">
                     {chapter.label}
                   </span>
                 </a>
@@ -76,9 +93,9 @@ export function Hero() {
             <span aria-hidden="true" className="select-none opacity-70">
               *&nbsp;
             </span>
-            Or better: run it yourself. Everything below answers back when you
-            press it. And view source whenever you like — skepticism is the
-            correct instinct.
+            Or don&apos;t take it on faith. Every panel below answers back when
+            you press it, and every one links to the code that did it.
+            Skepticism is the correct instinct.
           </MetaAside>
         </div>
       </Container>

--- a/apps/web/app/[locale]/components/marketing-button.tsx
+++ b/apps/web/app/[locale]/components/marketing-button.tsx
@@ -20,7 +20,7 @@ const variants = {
     "inline-flex items-center justify-center px-4 py-[calc(0.5rem-1px)]",
     "rounded-full border border-transparent bg-primary shadow-md",
     "whitespace-nowrap font-medium text-base text-primary-foreground",
-    "hover:bg-primary/90 disabled:opacity-40"
+    "transition-colors duration-200 hover:bg-primary/90 disabled:opacity-40"
   ),
   secondary: cn(
     "relative inline-flex items-center justify-center px-4 py-[calc(0.5rem-1px)]",

--- a/apps/web/app/[locale]/components/meta-aside.tsx
+++ b/apps/web/app/[locale]/components/meta-aside.tsx
@@ -4,7 +4,7 @@ interface MetaAsideProps {
   children: React.ReactNode;
   className?: string;
   noMarker?: boolean;
-  variant?: "inline" | "block";
+  variant?: "comment" | "inline" | "block";
 }
 
 export function MetaAside({
@@ -13,6 +13,25 @@ export function MetaAside({
   noMarker = false,
   variant = "inline",
 }: MetaAsideProps) {
+  if (variant === "comment") {
+    // The exhibit asides, set the way they read: a note an engineer left in
+    // this codebase. Comment-gray like the highlighted source's own comments,
+    // wrapped in the block markers, no brand color asking for credit.
+    return (
+      <aside
+        className={cn("font-mono text-muted-foreground text-sm/6", className)}
+      >
+        <span aria-hidden="true" className="select-none opacity-55">
+          {"/* "}
+        </span>
+        {children}
+        <span aria-hidden="true" className="select-none opacity-55">
+          {" */"}
+        </span>
+      </aside>
+    );
+  }
+
   if (variant === "block") {
     return (
       <aside

--- a/apps/web/app/[locale]/components/seats-cta.tsx
+++ b/apps/web/app/[locale]/components/seats-cta.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useCallback } from "react";
+import { MarketingButton } from "./marketing-button";
+
+/**
+ * The cohort CTA. As a plain #digest link it went dead after one press —
+ * same-hash navigations are no-ops — and a link can't hand the visitor a
+ * caret. This keeps the href (new tabs and no-JS visitors get the plain
+ * anchor) and upgrades the ordinary click: scroll to the digest, put the
+ * caret in the email field, keep the URL honest. Works every press.
+ */
+export function SeatsCta({ children }: { children: React.ReactNode }) {
+  const handleClick = useCallback((event: React.MouseEvent) => {
+    // Modified clicks (new tab, new window) keep native link behavior.
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+    event.preventDefault();
+    document.getElementById("digest")?.scrollIntoView();
+    // preventScroll: the section scroll above is already in flight (smooth,
+    // via the html element's scroll-smooth) — the focus shouldn't yank it.
+    document.getElementById("digest-email")?.focus({ preventScroll: true });
+    history.replaceState(null, "", "#digest");
+  }, []);
+
+  return (
+    <MarketingButton href="#digest" onClick={handleClick}>
+      {children}
+    </MarketingButton>
+  );
+}

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -185,9 +185,10 @@ async function ShellDemo() {
       }
       meta={
         <>
-          The ritual: clear the cache, hard refresh, clear it again, open an
-          incognito window, ask a colleague to load it. Five steps, three of
-          which quietly refill the entry you just cleared.
+          In your app, the two renders behind one press would read the same
+          database and agree — no visitor would ever see the seam. The bake is a
+          random id precisely so two renders can never agree. Watching a cache
+          work requires caching something that never repeats.
         </>
       }
       sourcePath="apps/web/app/[locale]/(playground)/shell"

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -83,7 +83,7 @@ export const metadata: Metadata = {
       },
     ],
   },
-  title: "hasToggle — the live playground for Next.js & Vercel",
+  title: "hasToggle — the unofficial live playground for Next.js & Vercel",
   twitter: {
     card: "summary_large_image",
   },

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -154,15 +154,15 @@ async function ShellDemo() {
 
   return (
     <DemoSection
-      belief="But I already revalidated it."
+      belief="It’s either cached or it isn’t."
       chapter="02"
       id="demo-02"
       intro={
         <>
           <p>
-            You did, and it worked: the entry was gone the instant you called
-            it, for every visitor at once. But a revalidation is a deletion with
-            a hopeful name. <InlineCode>use cache</InlineCode>&#32;bakes a
+            We believed it, too — hit or miss, there or not. But
+            &ldquo;cached&rdquo; is not a state a page is in; it is a bake with
+            a lifespan. <InlineCode>use cache</InlineCode>&#32;bakes a
             component&rsquo;s output into the page&rsquo;s static shell — one
             copy, served to everyone — and a cache tag is the handle you pull to
             throw that copy away. Pulling it empties the shelf and lights no
@@ -178,19 +178,23 @@ async function ShellDemo() {
           </p>
           <p>
             It is three. Flip the switch and run it again in slow motion — the
-            panel narrates each event as it happens. Watch the fingerprint: it
-            moves twice, not once, and the gap between those two moves is where
-            the argument happens — you insisting you already revalidated, the
-            page insisting it is stale, and both of you right.
+            panel narrates each event as it happens. Watch the color: it changes
+            twice, not once, and that gap is what your cache logs are naming.
+            Press the button here and the next request logs{" "}
+            <InlineCode>REVALIDATED</InlineCode> — reason:{" "}
+            <InlineCode>tag-based deletion</InlineCode> — because that request
+            was the refill. <InlineCode>STALE</InlineCode> is the same gap
+            handled softly: the old bake served while a fresh one is in the
+            oven.
           </p>
         </>
       }
       meta={
         <>
           In your app, the two renders behind one press would read the same
-          database and agree — no visitor would ever see the seam. The bake is a
-          random id precisely so two renders can never agree. Watching a cache
-          work requires caching something that never repeats.
+          database and agree — no visitor would ever see the seam. The bake here
+          is a random color value precisely so two renders can never agree.
+          Watching a cache work requires caching something that never repeats.
         </>
       }
       topic="caching & revalidation"
@@ -212,7 +216,7 @@ async function ShellDemo() {
           >
             <CodeBlock
               code={SHELL_SOURCE}
-              file="bake.ts + actions.ts"
+              file="bake.ts + actions.ts + the ask"
               variant="bar"
             />
           </ReferenceBar>

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -70,7 +70,7 @@ function PartDivider() {
 
 export const metadata: Metadata = {
   description:
-    "Five things developers believe about Next.js, each answered by the feature itself running on the page: the server/client boundary, caching, streaming, Server Actions, generated images. Press it, break it, read the code that did it. New exhibit every Monday.",
+    "Every exhibit takes something developers are sure about and runs the real feature next to it: the server/client boundary, caching, streaming, Server Actions, generated images. Poke it, break it, read the code that did it. New exhibit every Monday.",
   // Resolves the relative /api/og image below to an absolute URL in the
   // rendered og:image tag — crawlers don't do relative.
   metadataBase: new URL(env.NEXT_PUBLIC_WEB_URL),
@@ -161,8 +161,8 @@ async function ShellDemo() {
       intro={
         <>
           <p>
-            Clearing it and refilling it are two different events, and the page
-            is only fresh after the second one.{" "}
+            You cleared it. Nothing refilled it. Those are two different events,
+            and the page is only fresh after the second one.{" "}
             <InlineCode>use cache</InlineCode>&#32;bakes a component&apos;s
             output into the page&apos;s static shell. A cache tag is the handle
             you pull to throw that entry away. Pulling it does not put anything
@@ -212,7 +212,7 @@ async function ShellDemo() {
 function StreamDemo({ searchParams }: PageProps) {
   return (
     <DemoSection
-      belief="Nothing renders until the slowest part is ready."
+      belief="I’ll fetch it all first, then render."
       chapter="03"
       docs={{
         href: "https://nextjs.org/docs/app/api-reference/file-conventions/loading",
@@ -222,10 +222,10 @@ function StreamDemo({ searchParams }: PageProps) {
       intro={
         <>
           <p>
-            It used to. Suspense ended that. The static shell ships immediately,
-            each slow part shows its fallback, and the server streams finished
-            HTML into place over the same response as each part finishes.
-            Nothing waits for everything.
+            Not any more. The static shell ships immediately, each slow part
+            shows its fallback, and the server streams finished HTML into place
+            over the same response as each part finishes. Nothing waits for
+            everything.
           </p>
           <p>
             These three rows are slow on purpose. They resolve in delay order,
@@ -323,7 +323,7 @@ function MutationDemo() {
 function ImageDemo() {
   return (
     <DemoSection
-      belief="Every link preview is an image someone made by hand."
+      belief="I’ll need to design a card for every page."
       chapter="05"
       docs={{
         href: "https://nextjs.org/docs/app/api-reference/functions/image-response",
@@ -333,7 +333,7 @@ function ImageDemo() {
       intro={
         <>
           <p>
-            Someone drew the first one. <InlineCode>ImageResponse</InlineCode>
+            You&apos;ll design one. <InlineCode>ImageResponse</InlineCode>
             &#32;renders JSX to a PNG at request time, and it is a route handler
             like any other — query in, image out. One file draws the card for
             every page you will ever publish.
@@ -348,8 +348,8 @@ function ImageDemo() {
       meta={
         <>
           The fine print: it looks like CSS, but the renderer (Satori) only
-          understands flexbox. Grid users will be shown the door, politely, at
-          build time.
+          understands flexbox. Grid users will be shown the door, politely, the
+          moment the route runs.
         </>
       }
       sourcePath="apps/web/app/api/og"
@@ -453,7 +453,8 @@ function Cohort() {
               walls catch everyone — hydration, caching, the boundary, all the
               exhibits above. The playground shows you the wall. The cohort gets
               you over it: small paid groups, building production apps on
-              exactly these topics, AI workflow included.
+              exactly these topics, with the same AI workflow that built this
+              page.
             </p>
             <div className="mt-8 flex flex-col items-start gap-x-8 gap-y-4 sm:flex-row sm:items-center">
               <MarketingButton href="#digest">

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -106,13 +106,15 @@ function BoundaryDemo() {
       intro={
         <>
           <p>
-            Safer than what? Every component in the App Router already runs on
-            the server. <InlineCode>&quot;use client&quot;</InlineCode>&#32;is
-            not a precaution, it&rsquo;s a purchase — for that file and
-            everything it imports. You buy useState, useEffect and onClick. You
-            pay with the database call you can no longer make from here, the API
-            key you can no longer read, and however much React your visitor
-            downloads on their phone.
+            Safer than what? We reached for it the same way, for about a year,
+            before anyone made us say what it was protecting against. Every
+            component in the App Router already runs on the server.{" "}
+            <InlineCode>&quot;use client&quot;</InlineCode>&#32;is not a
+            precaution, it&rsquo;s a purchase — for that file and everything it
+            imports. You buy useState, useEffect and onClick. You pay with the
+            database call you can no longer make from here, the API key you can
+            no longer read, and however much React your visitor downloads on
+            their phone.
           </p>
           <p>
             One of these cards rendered in Node.js and arrived as finished HTML.
@@ -182,9 +184,9 @@ async function ShellDemo() {
       }
       meta={
         <>
-          &ldquo;Why is my page stale&rdquo; and &ldquo;why is my page
-          slow&rdquo; are one question read from opposite ends. Tune one and
-          you&rsquo;ve picked a side on the other, whether you meant to or not.
+          The ritual: clear the cache, hard refresh, clear it again, open an
+          incognito window, ask a colleague to load it. Five steps, three of
+          which quietly refill the entry you just cleared.
         </>
       }
       sourcePath="apps/web/app/[locale]/(playground)/shell"
@@ -228,9 +230,12 @@ function StreamDemo({ searchParams }: PageProps) {
             everything.
           </p>
           <p>
-            These three rows are slow on purpose. They resolve in delay order,
-            fastest first. Run it again and watch the order hold — the sequence
-            is the server finishing, not an animation.
+            These three rows are slow on purpose. The delays are hardcoded — the
+            only faked thing on this page — but the streaming is not: each row
+            is a Server Component that genuinely finishes on the server and
+            lands when it is done. Run it again and watch the order hold. What
+            you are seeing is the server finishing, not an animation pretending
+            to.
           </p>
         </>
       }
@@ -347,9 +352,9 @@ function ImageDemo() {
       }
       meta={
         <>
-          The workflow this replaces: open Figma, export at 1200&times;630, save
-          it as og-pricing-final-v3.png, wire up the path, then do the whole
-          thing again when someone rewrites the headline.
+          Every repo has an og-image-final-v2.png in it somewhere, quietly out
+          of date since the last time the headline changed. Nobody is coming to
+          update it, and now nobody has to.
         </>
       }
       sourcePath="apps/web/app/api/og"

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -347,9 +347,9 @@ function ImageDemo() {
       }
       meta={
         <>
-          The fine print: it looks like CSS, but the renderer (Satori) only
-          understands flexbox. Grid users will be shown the door, politely, the
-          moment the route runs.
+          The workflow this replaces: open Figma, export at 1200&times;630, save
+          it as og-pricing-final-v3.png, wire up the path, then do the whole
+          thing again when someone rewrites the headline.
         </>
       }
       sourcePath="apps/web/app/api/og"
@@ -357,7 +357,7 @@ function ImageDemo() {
     >
       <LivePanel
         label="/api/og"
-        readout="route handler · JSX → Satori → PNG · rendered per request, cached by nobody"
+        readout="route handler · JSX → Satori (flexbox only) → PNG · rendered per request, cached by nobody"
       >
         <OgDemo />
       </LivePanel>

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -108,7 +108,7 @@ function BoundaryDemo() {
           <p>
             Safer than what? Every component in the App Router already runs on
             the server. <InlineCode>&quot;use client&quot;</InlineCode>&#32;is
-            not a precaution, it&apos;s a purchase — for that file and
+            not a precaution, it&rsquo;s a purchase — for that file and
             everything it imports. You buy useState, useEffect and onClick. You
             pay with the database call you can no longer make from here, the API
             key you can no longer read, and however much React your visitor
@@ -124,8 +124,8 @@ function BoundaryDemo() {
       meta={
         <>
           The error that sends everyone here is &ldquo;useState only works in a
-          Client Component&rdquo;. The server isn&apos;t being difficult. It has
-          no clicks to listen for.
+          Client Component&rdquo;. The server isn&rsquo;t being difficult. It
+          has no clicks to listen for.
         </>
       }
       sourcePath="apps/web/app/[locale]/(playground)/boundary"
@@ -163,13 +163,13 @@ async function ShellDemo() {
           <p>
             You cleared it. Nothing refilled it. Those are two different events,
             and the page is only fresh after the second one.{" "}
-            <InlineCode>use cache</InlineCode>&#32;bakes a component&apos;s
-            output into the page&apos;s static shell. A cache tag is the handle
+            <InlineCode>use cache</InlineCode>&#32;bakes a component&rsquo;s
+            output into the page&rsquo;s static shell. A cache tag is the handle
             you pull to throw that entry away. Pulling it does not put anything
             back.
           </p>
           <p>
-            The stamp below is this page&apos;s own cache entry — one entry,
+            The stamp below is this page&rsquo;s own cache entry — one entry,
             shared by every visitor. Press the button and it is gone, for all of
             them, immediately.
           </p>
@@ -184,14 +184,14 @@ async function ShellDemo() {
         <>
           &ldquo;Why is my page stale&rdquo; and &ldquo;why is my page
           slow&rdquo; are one question read from opposite ends. Tune one and
-          you&apos;ve picked a side on the other, whether you meant to or not.
+          you&rsquo;ve picked a side on the other, whether you meant to or not.
         </>
       }
       sourcePath="apps/web/app/[locale]/(playground)/shell"
       topic="caching & revalidation"
     >
       <LivePanel
-        label="this page's own cache"
+        label="this page’s own cache"
         readout={
           <>
             cacheTag(&quot;landing-shell&quot;) · cacheLife(&quot;days&quot;) ·
@@ -280,7 +280,7 @@ function MutationDemo() {
         <>
           <p>
             You need a function. A Server Action lives on the server and plugs
-            straight into a form&apos;s <InlineCode>action</InlineCode>: no
+            straight into a form&rsquo;s <InlineCode>action</InlineCode>: no
             endpoint to design, no fetch to write, no JSON contract to keep in
             sync. The form calls the function, the function mutates, and Next.js
             re-renders the page around the result.
@@ -333,7 +333,7 @@ function ImageDemo() {
       intro={
         <>
           <p>
-            You&apos;ll design one. <InlineCode>ImageResponse</InlineCode>
+            You&rsquo;ll design one. <InlineCode>ImageResponse</InlineCode>
             &#32;renders JSX to a PNG at request time, and it is a route handler
             like any other — query in, image out. One file draws the card for
             every page you will ever publish.

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -371,16 +371,23 @@ function ImageDemo() {
 }
 
 const UPCOMING: readonly string[] = [
+  "navigation & prefetching",
   "dynamic routes & params",
   "next/image, fonts & the asset pipeline",
+  "metadata, sitemaps & SEO",
+  "optimistic UI & useActionState",
   "proxy, redirects & rewrites",
   "error, not-found & recovery",
   "parallel & intercepted routes",
-  "ISR at scale",
+  "i18n & locale routing",
+  "view transitions",
+  "ISR & pages baked on demand",
   "edge network & geolocation",
+  "feature flags & Edge Config",
+  "web vitals, measured live",
   "preview deploys & instant rollback",
   "cron, queues & background work",
-  "blob, KV & Postgres",
+  "blob, key-value & Postgres",
 ];
 
 function Roadmap() {

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -163,12 +163,11 @@ async function ShellDemo() {
       intro={
         <>
           <p>
-            You cleared it. Nothing refilled it. Those are two different events,
-            and the page is only fresh after the second one.{" "}
+            You cleared it. Nothing refilled it.{" "}
             <InlineCode>use cache</InlineCode>&#32;bakes a component&rsquo;s
             output into the page&rsquo;s static shell. A cache tag is the handle
-            you pull to throw that entry away. Pulling it does not put anything
-            back.
+            you pull to throw that entry away — pulling it does not put anything
+            back, and the page is only fresh once something does.
           </p>
           <p>
             The stamp below is this page&rsquo;s own cache entry — one entry,

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -193,20 +193,14 @@ async function ShellDemo() {
       sourcePath="apps/web/app/[locale]/(playground)/shell"
       topic="caching & revalidation"
     >
-      <LivePanel
-        label="this page’s own cache"
-        readout={
-          <>
-            cacheTag(&quot;landing-shell&quot;) · cacheLife(&quot;days&quot;) ·
-            one entry, shared by every visitor
-          </>
-        }
-      >
-        <div className="flex flex-col gap-6">
-          <BakedStamp bake={bake} />
-          <RebakePanel currentId={bake.id} />
-        </div>
-      </LivePanel>
+      {/* The client panel owns the instrument chrome here, because the
+          header gauge and the display's pending treatment follow its
+          transitions. The stamp stays a Server Component, threaded through
+          as a prop — the composition exhibit one teaches. No label (the
+          intro names the subject once) and no readout strip: cacheTag and
+          cacheLife are visible in the bake.ts source below, which is the
+          spec plate a reader who wants identifiers actually opens. */}
+      <RebakePanel currentId={bake.id} stamp={<BakedStamp bake={bake} />} />
       <CodeBlock code={SHELL_SOURCE} file="bake.ts + actions.ts" />
     </DemoSection>
   );

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "./(playground)/mutation/press-count";
 import { PressForm } from "./(playground)/mutation/press-form";
 import { MUTATION_SOURCE } from "./(playground)/mutation/source";
+import { ReferenceBar } from "./(playground)/reference-bar";
 import { getBake } from "./(playground)/shell/bake";
 import { BakedStamp } from "./(playground)/shell/baked-stamp";
 import { RebakePanel } from "./(playground)/shell/rebake-panel";
@@ -155,10 +156,6 @@ async function ShellDemo() {
     <DemoSection
       belief="I cleared the cache, so the page is fresh now."
       chapter="02"
-      docs={{
-        href: "https://nextjs.org/docs/app/getting-started/caching",
-        label: "Caching",
-      }}
       id="demo-02"
       intro={
         <>
@@ -191,7 +188,6 @@ async function ShellDemo() {
           work requires caching something that never repeats.
         </>
       }
-      sourcePath="apps/web/app/[locale]/(playground)/shell"
       topic="caching & revalidation"
     >
       {/* The client panel owns the instrument chrome here, because the
@@ -199,10 +195,25 @@ async function ShellDemo() {
           transitions. The stamp stays a Server Component, threaded through
           as a prop — the composition exhibit one teaches. No label (the
           intro names the subject once) and no readout strip: cacheTag and
-          cacheLife are visible in the bake.ts source below, which is the
-          spec plate a reader who wants identifiers actually opens. */}
-      <RebakePanel currentId={bake.id} stamp={<BakedStamp bake={bake} />} />
-      <CodeBlock code={SHELL_SOURCE} file="bake.ts + actions.ts" />
+          cacheLife are visible in the bake.ts source, one drawer down in
+          the reference bar, which is the spec plate a reader who wants
+          identifiers actually opens. */}
+      <RebakePanel
+        currentId={bake.id}
+        references={
+          <ReferenceBar
+            docsHref="https://nextjs.org/docs/app/getting-started/caching"
+            sourceHref="https://github.com/hasToggle/hasToggle.dev/tree/main/apps/web/app/%5Blocale%5D/(playground)/shell"
+          >
+            <CodeBlock
+              code={SHELL_SOURCE}
+              file="bake.ts + actions.ts"
+              variant="bar"
+            />
+          </ReferenceBar>
+        }
+        stamp={<BakedStamp bake={bake} />}
+      />
     </DemoSection>
   );
 }

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -171,12 +171,14 @@ async function ShellDemo() {
           </p>
           <p>
             The stamp below is this page&rsquo;s own cache entry — one entry,
-            shared by every visitor. Press the button and it is gone, for all of
-            them, immediately.
+            shared by every visitor. Press the button and a fresh bake lands for
+            all of them, in the time it takes the label to change back. It feels
+            like one event.
           </p>
           <p>
-            Then fetch what is actually cached now. The fingerprint moves twice,
-            not once, and the gap between those two moves is where every
+            It is three. Flip the switch and run it again in slow motion — the
+            panel narrates each event as it happens. The fingerprint moves
+            twice, not once, and the gap between those two moves is where every
             &ldquo;but I already revalidated it&rdquo; ticket lives.
           </p>
         </>

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -70,7 +70,7 @@ function PartDivider() {
 
 export const metadata: Metadata = {
   description:
-    "Interactive demos of Next.js and Vercel — caching, streaming, server actions, generated images. Press the buttons, break the cache, read the code that did it. New exhibit every Monday.",
+    "Five things developers believe about Next.js, each answered by the feature itself running on the page: the server/client boundary, caching, streaming, Server Actions, generated images. Press it, break it, read the code that did it. New exhibit every Monday.",
   // Resolves the relative /api/og image below to an absolute URL in the
   // rendered og:image tag — crawlers don't do relative.
   metadataBase: new URL(env.NEXT_PUBLIC_WEB_URL),
@@ -96,34 +96,35 @@ interface PageProps {
 function BoundaryDemo() {
   return (
     <DemoSection
+      belief="I’ll put “use client” on it, to be safe."
       chapter="01"
       docs={{
         href: "https://nextjs.org/docs/app/getting-started/server-and-client-components",
         label: "Server and Client Components",
       }}
-      hook="Two components walk into a page."
       id="demo-01"
       intro={
         <>
           <p>
-            Every component in the App Router runs on the server unless you say
-            otherwise. One directive —{" "}
-            <InlineCode>&quot;use client&quot;</InlineCode>&#32;— moves a
-            subtree into the browser. Everything else follows from that split:
-            what can read secrets, what can hold state, what ships JavaScript
-            and what arrives as finished HTML.
+            Safer than what? Every component in the App Router already runs on
+            the server. <InlineCode>&quot;use client&quot;</InlineCode>&#32;is
+            not a precaution, it&apos;s a purchase — for that file and
+            everything it imports. You buy state, effects and event handlers.
+            You spend the secrets, the direct data access, and the JavaScript
+            your visitor now downloads.
           </p>
           <p>
             One of these cards rendered in Node.js and arrived as finished HTML.
-            The other hydrated in your tab and is waiting for you to click it.
+            The other hydrated in your tab and is waiting for a click. Only one
+            of them knows what version of Node it is running on.
           </p>
         </>
       }
       meta={
         <>
           The error that sends everyone here is &ldquo;useState only works in a
-          Client Component&rdquo;. Now you know why: the server has no clicks to
-          listen for.
+          Client Component&rdquo;. It is not a restriction. The server has no
+          clicks to listen for.
         </>
       }
       sourcePath="apps/web/app/[locale]/(playground)/boundary"
@@ -149,40 +150,41 @@ async function ShellDemo() {
 
   return (
     <DemoSection
+      belief="I cleared the cache, so the page is fresh now."
       chapter="02"
       docs={{
         href: "https://nextjs.org/docs/app/getting-started/caching",
         label: "Caching",
       }}
-      hook="This page was baked before you arrived."
       id="demo-02"
       intro={
         <>
           <p>
-            Static doesn&apos;t mean written by hand, and dynamic doesn&apos;t
-            mean every visitor pays full price.{" "}
+            Clearing it and refilling it are two different events, and the page
+            is only fresh after the second one.{" "}
             <InlineCode>use cache</InlineCode>&#32;bakes a component&apos;s
-            output into the page&apos;s static shell; a cache tag gives you a
-            handle to expire it on demand.
+            output into the page&apos;s static shell. A cache tag is the handle
+            you pull to throw that entry away. Pulling it does not put anything
+            back.
           </p>
           <p>
-            The stamp below is this page&apos;s cache entry. Press the button
-            and it expires — for every visitor, instantly. Nobody ever lets you
-            press this button. Go on.
+            The stamp below is this page&apos;s own cache entry — one entry,
+            shared by every visitor. Press the button and it is gone, for all of
+            them, immediately.
           </p>
           <p>
-            Then fetch what&apos;s actually cached. The fingerprint changes
-            twice, not once: expiring an entry and refilling it are two
-            different events, and the gap between them is where &ldquo;why is my
-            page still stale&rdquo; lives.
+            Then fetch what is actually cached now. The fingerprint moves twice,
+            not once. Expiring an entry and refilling it are separate events,
+            and the gap between them is the answer to the question you came here
+            with.
           </p>
         </>
       }
       meta={
         <>
           &ldquo;Why is my page stale&rdquo; and &ldquo;why is my page
-          slow&rdquo; are the same question read from opposite ends. This demo
-          is both answers.
+          slow&rdquo; are one question read from opposite ends. Tune one and you
+          have chosen the other.
         </>
       }
       sourcePath="apps/web/app/[locale]/(playground)/shell"
@@ -210,31 +212,32 @@ async function ShellDemo() {
 function StreamDemo({ searchParams }: PageProps) {
   return (
     <DemoSection
+      belief="Nothing renders until the slowest part is ready."
       chapter="03"
       docs={{
         href: "https://nextjs.org/docs/app/api-reference/file-conventions/loading",
         label: "Streaming and loading UI",
       }}
-      hook="The page refused to wait."
       id="demo-03"
       intro={
         <>
           <p>
-            Slow data used to hold the whole page hostage. With Suspense, the
-            static shell ships immediately, every slow part shows its fallback,
-            and the server streams finished HTML into place — over the same
-            response — whenever each part is done.
+            It used to. Suspense ends the arrangement. The static shell ships
+            immediately, each slow part shows its fallback, and the server
+            streams finished HTML into place over the same response as each part
+            finishes. Nothing waits for everything.
           </p>
           <p>
-            These three rows are slow on purpose. Watch the skeletons resolve in
-            delay order — fastest first, slowest last. Then make it do it again.
+            These three rows are slow on purpose. They resolve in delay order,
+            fastest first. Run it again and watch the order hold — the sequence
+            is the server finishing, not an animation.
           </p>
         </>
       }
       meta={
         <>
-          loading.tsx is this exact mechanism wearing route-sized clothes. One
-          file, and your whole segment gets a fallback.
+          loading.tsx is this same mechanism wearing route-sized clothes. One
+          file, and the whole segment gets a fallback.
         </>
       }
       sourcePath="apps/web/app/[locale]/(playground)/stream"
@@ -266,33 +269,34 @@ function StreamDemo({ searchParams }: PageProps) {
 function MutationDemo() {
   return (
     <DemoSection
+      belief="You need an API route for that."
       chapter="04"
       docs={{
         href: "https://nextjs.org/docs/app/getting-started/updating-data",
         label: "Updating data with Server Actions",
       }}
-      hook="A form with no API route."
       id="demo-04"
       intro={
         <>
           <p>
-            A Server Action is a function that lives on the server and plugs
-            straight into a form&apos;s <InlineCode>action</InlineCode>. No
-            endpoint to design, no fetch, no JSON contract — the form invokes
-            the function, the function mutates, and Next.js re-renders the page
-            with the result.
+            You need a function. A Server Action lives on the server and plugs
+            straight into a form&apos;s <InlineCode>action</InlineCode>: no
+            endpoint to design, no fetch to write, no JSON contract to keep in
+            sync with itself. The form calls the function, the function mutates,
+            and Next.js re-renders the page around the result.
           </p>
           <p>
-            This one increments a counter stored in an httpOnly cookie. The
-            number is read back by a Server Component — the JavaScript in your
-            tab never touches it, and couldn&apos;t if it tried.
+            This one increments a counter held in an httpOnly cookie, read back
+            by a Server Component. The JavaScript in your tab never touches that
+            value, and could not if it tried.
           </p>
         </>
       }
       meta={
         <>
-          Somewhere, a 2019 tutorial is still teaching you to build{" "}
-          <InlineCode>/api/increment</InlineCode>. It can rest now.
+          Somewhere a tutorial is still walking you through{" "}
+          <InlineCode>/api/increment</InlineCode>. Nothing in it was wrong. It
+          just stopped being necessary.
         </>
       }
       sourcePath="apps/web/app/[locale]/(playground)/mutation"
@@ -317,25 +321,25 @@ function MutationDemo() {
 function ImageDemo() {
   return (
     <DemoSection
+      belief="Every link preview is an image someone made by hand."
       chapter="05"
       docs={{
         href: "https://nextjs.org/docs/app/api-reference/functions/image-response",
         label: "ImageResponse",
       }}
-      hook="An image that didn't exist a second ago."
       id="demo-05"
       intro={
         <>
           <p>
-            <InlineCode>ImageResponse</InlineCode>&#32;turns JSX into a PNG at
-            request time — it&apos;s how sites generate a link-preview card per
-            page instead of per designer. Under the hood it&apos;s a route
-            handler like any other: query in, image out.
+            Someone drew the first one. <InlineCode>ImageResponse</InlineCode>
+            &#32;renders JSX to a PNG at request time, and it is a route handler
+            like any other — query in, image out. One file draws the card for
+            every page you will ever publish.
           </p>
           <p>
-            Type a title and the server draws your card. The same endpoint makes
-            the link preview for this page — and the pattern carries to every
-            page you&apos;ll ever need a card for.
+            Type a title and the server draws it. The same endpoint made the
+            link preview for this page, which is how you can check the claim
+            without taking our word for it.
           </p>
         </>
       }
@@ -377,51 +381,54 @@ function Roadmap() {
   return (
     <section aria-labelledby="roadmap-heading" id="roadmap">
       <Container className="py-24 sm:py-32">
-        <div className="mb-14 max-w-2xl">
-          <Subheading>The syllabus grows</Subheading>
-          <Heading
-            as="h2"
-            className="mt-3 text-balance text-4xl sm:text-5xl md:text-6xl"
-            id="roadmap-heading"
-          >
-            Five exhibits. Dozens to go.
-          </Heading>
-          <p className="mt-6 text-foreground/75 text-lg leading-8">
-            The plan is everything Next.js has to offer — and as much of the
-            Vercel platform as can be demonstrated from inside a web page. One
-            exhibit at a time, in public.
-          </p>
-        </div>
-
-        <ul className="grid max-w-3xl grid-cols-1 gap-x-12 gap-y-3 font-mono text-muted-foreground text-sm/6 sm:grid-cols-2">
-          {UPCOMING.map((item) => (
-            <li className="flex items-baseline gap-3" key={item}>
-              <span
-                aria-hidden="true"
-                className="select-none text-ht-cyan-700/60 dark:text-ht-cyan-300/60"
-              >
-                +
-              </span>
-              {item}
-            </li>
-          ))}
-        </ul>
-
-        <div className="mt-16 max-w-2xl">
-          <MetaAside variant="block">
-            Built in the open: the{" "}
-            <a
-              className="underline decoration-ht-cyan-700/40 underline-offset-2 hover:decoration-ht-cyan-700"
-              href="https://github.com/hasToggle/hasToggle.dev"
-              rel="noreferrer"
-              target="_blank"
+        {/* The empty rail keeps the page on one left edge without numbering a
+            section that isn't an exhibit. */}
+        <div className="grid gap-x-12 gap-y-8 lg:grid-cols-[7rem_minmax(0,1fr)]">
+          <div aria-hidden="true" />
+          <div className="ht-reveal">
+            <Subheading>The syllabus grows</Subheading>
+            <Heading
+              as="h2"
+              className="mt-3 max-w-2xl text-balance text-4xl sm:text-5xl md:text-6xl"
+              id="roadmap-heading"
             >
-              repo is public
-            </a>
-            , and the building is done with AI — Conductor orchestrating Claude
-            Code, with the process published alongside via Entire.io. You get
-            the playground and the making-of.
-          </MetaAside>
+              Still to build.
+            </Heading>
+            <p className="mt-6 max-w-2xl text-foreground/75 text-lg leading-8">
+              The plan is everything Next.js can do, and as much of Vercel as
+              can be proved from inside a web page. One exhibit at a time, in
+              public.
+            </p>
+
+            <ul className="mt-14 grid max-w-3xl grid-cols-1 gap-x-12 gap-y-3 font-mono text-muted-foreground text-sm/6 sm:grid-cols-2">
+              {UPCOMING.map((item) => (
+                <li className="flex items-baseline gap-3" key={item}>
+                  <span
+                    aria-hidden="true"
+                    className="select-none text-ht-cyan-700/60 dark:text-ht-cyan-300/60"
+                  >
+                    +
+                  </span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+
+            <MetaAside className="mt-16 max-w-2xl" variant="block">
+              Built in the open: the{" "}
+              <a
+                className="underline decoration-ht-cyan-700/40 underline-offset-2 transition-colors hover:decoration-ht-cyan-700"
+                href="https://github.com/hasToggle/hasToggle.dev"
+                rel="noreferrer"
+                target="_blank"
+              >
+                repo is public
+              </a>
+              , and the building is done with AI — Conductor orchestrating
+              Claude Code, with the process published alongside via Entire.io.
+              You get the playground and the making-of.
+            </MetaAside>
+          </div>
         </div>
       </Container>
     </section>
@@ -434,7 +441,7 @@ function Cohort() {
       <Container className="py-24 sm:py-32">
         <div className="grid gap-x-12 gap-y-6 lg:grid-cols-[7rem_minmax(0,1fr)]">
           <div aria-hidden="true" />
-          <div className="max-w-2xl">
+          <div className="ht-reveal max-w-2xl">
             <Subheading id="cohort-heading">The cohort</Subheading>
             <Heading as="h2" className="mt-3 text-balance text-4xl sm:text-5xl">
               Some things move faster with a coach.
@@ -448,7 +455,7 @@ function Cohort() {
             </p>
             <div className="mt-8 flex flex-col items-start gap-x-8 gap-y-4 sm:flex-row sm:items-center">
               <MarketingButton href="#digest">
-                Get first dibs on seats
+                Tell me when seats open
               </MarketingButton>
               <MetaAside className="sm:max-w-xs">
                 Paid, small, and honest about both.
@@ -469,7 +476,7 @@ function DigestCTA() {
       id="digest"
     >
       <Container>
-        <div className="mx-auto flex max-w-2xl flex-col items-center text-center">
+        <div className="ht-reveal mx-auto flex max-w-2xl flex-col items-center text-center">
           <Subheading className="text-ht-cyan-800/80 dark:text-ht-cyan-300/80">
             The weekly build
           </Subheading>
@@ -491,8 +498,8 @@ function DigestCTA() {
             <Digest />
           </div>
           <MetaAside className="mt-6">
-            The fact that you&apos;re reading the fine print under an email form
-            says something about you. Something good.
+            One email a week. Unsubscribing is one click, and it works the first
+            time.
           </MetaAside>
         </div>
       </Container>
@@ -501,8 +508,12 @@ function DigestCTA() {
 }
 
 export default function MarketingPage({ searchParams }: PageProps) {
+  // `overflow-x-clip`, not `overflow-hidden`: clipping stops the full-bleed
+  // rules from widening the page, but unlike `hidden` it does not turn this
+  // element into a scroll container — which is what the scroll-driven reveals
+  // resolve against. See `.ht-reveal` in app/styles.css.
   return (
-    <div className="overflow-hidden">
+    <div className="overflow-x-clip">
       <Hero />
       <main>
         <BoundaryDemo />
@@ -516,6 +527,7 @@ export default function MarketingPage({ searchParams }: PageProps) {
         <ImageDemo />
         <PartDivider />
         <Roadmap />
+        <SectionDivider />
         <Cohort />
         <DigestCTA />
         <FrequentlyAskedQuestions />

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -154,17 +154,20 @@ async function ShellDemo() {
 
   return (
     <DemoSection
-      belief="I cleared the cache, so the page is fresh now."
+      belief="But I already revalidated it."
       chapter="02"
       id="demo-02"
       intro={
         <>
           <p>
-            You cleared it. Nothing refilled it.{" "}
-            <InlineCode>use cache</InlineCode>&#32;bakes a component&rsquo;s
-            output into the page&rsquo;s static shell. A cache tag is the handle
-            you pull to throw that entry away — pulling it does not put anything
-            back, and the page is only fresh once something does.
+            You did, and it worked: the entry was gone the instant you called
+            it, for every visitor at once. But a revalidation is a deletion with
+            a hopeful name. <InlineCode>use cache</InlineCode>&#32;bakes a
+            component&rsquo;s output into the page&rsquo;s static shell; a cache
+            tag is the handle you pull to throw that entry away. Pulling it
+            renders nothing — the fresh page takes a request, and until one
+            arrives, &ldquo;revalidated&rdquo; and &ldquo;stale&rdquo; are both
+            true.
           </p>
           <p>
             The stamp below is this page&rsquo;s own cache entry — one entry,
@@ -175,8 +178,8 @@ async function ShellDemo() {
           <p>
             It is three. Flip the switch and run it again in slow motion — the
             panel narrates each event as it happens. The fingerprint moves
-            twice, not once, and the gap between those two moves is where every
-            &ldquo;but I already revalidated it&rdquo; ticket lives.
+            twice, not once, and the gap between those two moves is where you
+            were standing when you said it.
           </p>
         </>
       }

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -38,8 +38,8 @@ import { Digest } from "./components/digest";
 import { FrequentlyAskedQuestions } from "./components/faqs";
 import { Footer } from "./components/footer";
 import { Hero } from "./components/hero";
-import { MarketingButton } from "./components/marketing-button";
 import { MetaAside } from "./components/meta-aside";
+import { SeatsCta } from "./components/seats-cta";
 import { Heading, Subheading } from "./components/text";
 
 function SectionDivider() {
@@ -512,9 +512,7 @@ function Cohort() {
               page.
             </p>
             <div className="mt-8 flex flex-col items-start gap-x-8 gap-y-4 sm:flex-row sm:items-center">
-              <MarketingButton href="#digest">
-                Tell me when seats open
-              </MarketingButton>
+              <SeatsCta>Tell me when seats open</SeatsCta>
               <MetaAside className="sm:max-w-xs">
                 Paid, small, and honest about both.
               </MetaAside>

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -163,23 +163,25 @@ async function ShellDemo() {
             You did, and it worked: the entry was gone the instant you called
             it, for every visitor at once. But a revalidation is a deletion with
             a hopeful name. <InlineCode>use cache</InlineCode>&#32;bakes a
-            component&rsquo;s output into the page&rsquo;s static shell; a cache
-            tag is the handle you pull to throw that entry away. Pulling it
-            renders nothing — the fresh page takes a request, and until one
-            arrives, &ldquo;revalidated&rdquo; and &ldquo;stale&rdquo; are both
-            true.
+            component&rsquo;s output into the page&rsquo;s static shell — one
+            copy, served to everyone — and a cache tag is the handle you pull to
+            throw that copy away. Pulling it empties the shelf and lights no
+            oven. The fresh page is baked when the next request asks for one,
+            and not a moment before.
           </p>
           <p>
-            The stamp below is this page&rsquo;s own cache entry — one entry,
-            shared by every visitor. Press the button and a fresh bake lands for
-            all of them, in the time it takes the label to change back. It feels
-            like one event.
+            The stamp below is that copy — this page&rsquo;s own cache entry,
+            wearing a six-character fingerprint so you can tell one bake from
+            the next. Press the button and a fresh bake lands for every visitor,
+            in the time it takes the label to change back. It feels like one
+            event.
           </p>
           <p>
             It is three. Flip the switch and run it again in slow motion — the
-            panel narrates each event as it happens. The fingerprint moves
-            twice, not once, and the gap between those two moves is where you
-            were standing when you said it.
+            panel narrates each event as it happens. Watch the fingerprint: it
+            moves twice, not once, and the gap between those two moves is where
+            the argument happens — you insisting you already revalidated, the
+            page insisting it is stale, and both of you right.
           </p>
         </>
       }

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -5,10 +5,7 @@ import { DEFAULT_OG_TITLE } from "@/app/api/og/title";
 import { env } from "@/env";
 import { ClientCard } from "./(playground)/boundary/client-card";
 import { ServerCard } from "./(playground)/boundary/server-card";
-import {
-  CLIENT_CARD_SOURCE,
-  SERVER_CARD_SOURCE,
-} from "./(playground)/boundary/source";
+import { BOUNDARY_SOURCE } from "./(playground)/boundary/source";
 import { CodeBlock } from "./(playground)/code-block";
 import { DemoSection } from "./(playground)/demo-section";
 import { OgDemo } from "./(playground)/image/og-demo";
@@ -36,6 +33,7 @@ import {
   StreamRowsFallback,
 } from "./(playground)/stream/stream-rows";
 import { Container } from "./components/container";
+import { ContentsNav } from "./components/contents-nav";
 import { Digest } from "./components/digest";
 import { FrequentlyAskedQuestions } from "./components/faqs";
 import { Footer } from "./components/footer";
@@ -99,10 +97,6 @@ function BoundaryDemo() {
     <DemoSection
       belief="I’ll put “use client” on it, to be safe."
       chapter="01"
-      docs={{
-        href: "https://nextjs.org/docs/app/getting-started/server-and-client-components",
-        label: "Server and Client Components",
-      }}
       id="demo-01"
       intro={
         <>
@@ -118,9 +112,11 @@ function BoundaryDemo() {
             their phone.
           </p>
           <p>
-            One of these cards rendered in Node.js and arrived as finished HTML.
-            The other hydrated in your tab and is waiting for a click. Only one
-            of them knows what version of Node it is running on.
+            Watch the two cards below. One rendered in Node.js and arrived as
+            finished HTML — done before you got here. The other arrived as
+            JavaScript and woke up in your tab — the waking is called hydration
+            — and its button is waiting for a click. Only one of them is running
+            Node, and it prints the version to prove it.
           </p>
         </>
       }
@@ -131,20 +127,33 @@ function BoundaryDemo() {
           has no clicks to listen for.
         </>
       }
-      sourcePath="apps/web/app/[locale]/(playground)/boundary"
       topic="server & client components"
     >
       <LivePanel
-        label="two components, one page"
-        readout="boundary drawn at the import graph · props cross it as serialized data"
+        references={
+          <ReferenceBar
+            docsHref="https://nextjs.org/docs/app/getting-started/server-and-client-components"
+            sourceHref="https://github.com/hasToggle/hasToggle.dev/tree/main/apps/web/app/%5Blocale%5D/(playground)/boundary"
+          >
+            <CodeBlock
+              code={BOUNDARY_SOURCE}
+              file="server-card.tsx + client-card.tsx"
+            />
+          </ReferenceBar>
+        }
       >
-        <div className="grid gap-4 sm:grid-cols-2">
-          <ServerCard />
-          <ClientCard />
+        <div className="flex flex-col gap-5">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <ServerCard />
+            <ClientCard />
+          </div>
+          {/* The seam, narrated: the one fact neither card can state alone. */}
+          <p className="font-mono text-muted-foreground text-xs/5">
+            props cross the boundary as serialized data — the import graph
+            decides which side a component runs on.
+          </p>
         </div>
       </LivePanel>
-      <CodeBlock code={SERVER_CARD_SOURCE} file="server-card.tsx" />
-      <CodeBlock code={CLIENT_CARD_SOURCE} file="client-card.tsx" />
     </DemoSection>
   );
 }
@@ -217,7 +226,6 @@ async function ShellDemo() {
             <CodeBlock
               code={SHELL_SOURCE}
               file="bake.ts + actions.ts + the ask"
-              variant="bar"
             />
           </ReferenceBar>
         }
@@ -232,18 +240,15 @@ function StreamDemo({ searchParams }: PageProps) {
     <DemoSection
       belief="I’ll fetch it all first, then render."
       chapter="03"
-      docs={{
-        href: "https://nextjs.org/docs/app/api-reference/file-conventions/loading",
-        label: "Streaming and loading UI",
-      }}
       id="demo-03"
       intro={
         <>
           <p>
-            Not any more. The static shell ships immediately, each slow part
-            shows its fallback, and the server streams finished HTML into place
-            over the same response as each part finishes. Nothing waits for
-            everything.
+            Not any more. The static shell ships immediately, and each slow part
+            leaves behind a fallback — the gray placeholder you&rsquo;ll watch
+            below. As each part finishes, the server streams its finished HTML
+            down the same response, and the placeholder gives way. The fast
+            parts don&rsquo;t wait for the slow ones.
           </p>
           <p>
             These three rows are slow on purpose. The delays are hardcoded — the
@@ -261,28 +266,31 @@ function StreamDemo({ searchParams }: PageProps) {
           file, and the whole segment gets a fallback.
         </>
       }
-      sourcePath="apps/web/app/[locale]/(playground)/stream"
       topic="streaming & suspense"
     >
+      {/* The rerun control keeps its own Suspense boundary (it reads the
+          URL, which is runtime data) so the deck can hold it while the rows
+          stream in the body — the rows' skeletons are the in-flight signal,
+          arriving in delay order. */}
       <LivePanel
-        label="the server, cooking"
-        readout="3 Suspense boundaries · re-keyed by ?stream= · the shell never waited for any of them"
-      >
-        <div className="flex flex-col gap-5">
-          <Suspense
-            fallback={
-              <>
-                <RerunButtonFallback />
-                <StreamRowsFallback />
-              </>
-            }
-          >
+        deck={
+          <Suspense fallback={<RerunButtonFallback />}>
             <RerunButton />
-            <StreamRows searchParams={searchParams} />
           </Suspense>
-        </div>
+        }
+        references={
+          <ReferenceBar
+            docsHref="https://nextjs.org/docs/app/api-reference/file-conventions/loading"
+            sourceHref="https://github.com/hasToggle/hasToggle.dev/tree/main/apps/web/app/%5Blocale%5D/(playground)/stream"
+          >
+            <CodeBlock code={STREAM_SOURCE} file="slow-row.tsx" />
+          </ReferenceBar>
+        }
+      >
+        <Suspense fallback={<StreamRowsFallback />}>
+          <StreamRows searchParams={searchParams} />
+        </Suspense>
       </LivePanel>
-      <CodeBlock code={STREAM_SOURCE} file="slow-row.tsx" />
     </DemoSection>
   );
 }
@@ -292,10 +300,6 @@ function MutationDemo() {
     <DemoSection
       belief="You need an API route for that."
       chapter="04"
-      docs={{
-        href: "https://nextjs.org/docs/app/getting-started/updating-data",
-        label: "Updating data with Server Actions",
-      }}
       id="demo-04"
       intro={
         <>
@@ -303,13 +307,15 @@ function MutationDemo() {
             You need a function. A Server Action lives on the server and plugs
             straight into a form&rsquo;s <InlineCode>action</InlineCode>: no
             endpoint to design, no fetch to write, no JSON contract to keep in
-            sync. The form calls the function, the function mutates, and Next.js
-            re-renders the page around the result.
+            sync. Press the button below and follow the trip: the form calls the
+            function, the function adds one, and Next.js re-renders the page
+            around the new number.
           </p>
           <p>
-            This one increments a counter held in an httpOnly cookie, read back
-            by a Server Component. The JavaScript in your tab never touches that
-            value, and could not if it tried.
+            This one keeps its count in a cookie your browser carries but your
+            JavaScript cannot open — that is what httpOnly means — and a Server
+            Component reads it back. The JavaScript in your tab never touches
+            the value, and could not if it tried.
           </p>
         </>
       }
@@ -322,12 +328,24 @@ function MutationDemo() {
           number.
         </>
       }
-      sourcePath="apps/web/app/[locale]/(playground)/mutation"
       topic="server actions & cookies"
     >
+      {/* The form stays in the body: it is the specimen, not instrument
+          chrome — a form wired straight to a Server Action is the entire
+          lesson, and moving it into the deck would file the exhibit's
+          subject under controls. */}
       <LivePanel
-        label="your cookie, read server-side"
-        readout="httpOnly cookie · written by a Server Action · the page re-renders itself"
+        references={
+          <ReferenceBar
+            docsHref="https://nextjs.org/docs/app/getting-started/updating-data"
+            sourceHref="https://github.com/hasToggle/hasToggle.dev/tree/main/apps/web/app/%5Blocale%5D/(playground)/mutation"
+          >
+            <CodeBlock
+              code={MUTATION_SOURCE}
+              file="actions.ts + press-form.tsx"
+            />
+          </ReferenceBar>
+        }
       >
         <div className="flex flex-col gap-6">
           <Suspense fallback={<PressCountFallback />}>
@@ -336,7 +354,6 @@ function MutationDemo() {
           <PressForm />
         </div>
       </LivePanel>
-      <CodeBlock code={MUTATION_SOURCE} file="actions.ts + press-form.tsx" />
     </DemoSection>
   );
 }
@@ -346,18 +363,15 @@ function ImageDemo() {
     <DemoSection
       belief="I’ll need to design a card for every page."
       chapter="05"
-      docs={{
-        href: "https://nextjs.org/docs/app/api-reference/functions/image-response",
-        label: "ImageResponse",
-      }}
       id="demo-05"
       intro={
         <>
           <p>
             You&rsquo;ll design one. <InlineCode>ImageResponse</InlineCode>
-            &#32;renders JSX to a PNG at request time, and it is a route handler
-            like any other — query in, image out. One file draws the card for
-            every page you will ever publish.
+            &#32;turns JSX — the same markup your components are made of — into
+            a PNG the moment a request asks, and it is a route handler like any
+            other: query in, image out. One file draws the card for every page
+            you will ever publish.
           </p>
           <p>
             Type a title and the server draws it. The same endpoint drew the
@@ -373,16 +387,21 @@ function ImageDemo() {
           update it, and now nobody has to.
         </>
       }
-      sourcePath="apps/web/app/api/og"
       topic="imageresponse & route handlers"
     >
-      <LivePanel
-        label="/api/og"
-        readout="route handler · JSX → Satori (flexbox only) → PNG · rendered per request, cached by nobody"
-      >
-        <OgDemo />
-      </LivePanel>
-      <CodeBlock code={OG_SOURCE} file="app/api/og/route.tsx" />
+      {/* OgDemo owns the instrument: the gauge follows its fetch state, the
+          title form is its deck. The reference bar threads through as a prop
+          because CodeBlock renders on the server. */}
+      <OgDemo
+        references={
+          <ReferenceBar
+            docsHref="https://nextjs.org/docs/app/api-reference/functions/image-response"
+            sourceHref="https://github.com/hasToggle/hasToggle.dev/tree/main/apps/web/app/api/og"
+          >
+            <CodeBlock code={OG_SOURCE} file="app/api/og/route.tsx" />
+          </ReferenceBar>
+        }
+      />
     </DemoSection>
   );
 }
@@ -455,8 +474,16 @@ function Roadmap() {
                 repo is public
               </a>
               , and the building is done with AI — Conductor orchestrating
-              Claude Code, with the process published alongside via Entire.io.
-              You get the playground and the making-of.
+              Claude Code, with{" "}
+              <a
+                className="underline decoration-ht-cyan-700/40 underline-offset-2 transition-colors hover:decoration-ht-cyan-700"
+                href="https://github.com/hasToggle/hasToggle.dev-checkpoints"
+                rel="noreferrer"
+                target="_blank"
+              >
+                every prompt and checkpoint published
+              </a>{" "}
+              as they happen. You get the playground and the making-of.
             </MetaAside>
           </div>
         </div>
@@ -547,15 +574,22 @@ export default function MarketingPage({ searchParams }: PageProps) {
     <div className="overflow-x-clip">
       <Hero />
       <main>
-        <BoundaryDemo />
-        <SectionDivider />
-        <ShellDemo />
-        <SectionDivider />
-        <StreamDemo searchParams={searchParams} />
-        <SectionDivider />
-        <MutationDemo />
-        <SectionDivider />
-        <ImageDemo />
+        {/* This wrapper is the contents bar's sticky bound: the bar pins to
+            the viewport while the visitor is among the exhibits and releases
+            when the wrapper ends after demo 05 — the roadmap onward scrolls
+            nav-free, with no JavaScript deciding anything. */}
+        <div>
+          <ContentsNav />
+          <BoundaryDemo />
+          <SectionDivider />
+          <ShellDemo />
+          <SectionDivider />
+          <StreamDemo searchParams={searchParams} />
+          <SectionDivider />
+          <MutationDemo />
+          <SectionDivider />
+          <ImageDemo />
+        </div>
         <PartDivider />
         <Roadmap />
         <SectionDivider />

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -109,9 +109,10 @@ function BoundaryDemo() {
             Safer than what? Every component in the App Router already runs on
             the server. <InlineCode>&quot;use client&quot;</InlineCode>&#32;is
             not a precaution, it&apos;s a purchase — for that file and
-            everything it imports. You buy state, effects and event handlers.
-            You spend the secrets, the direct data access, and the JavaScript
-            your visitor now downloads.
+            everything it imports. You buy useState, useEffect and onClick. You
+            pay with the database call you can no longer make from here, the API
+            key you can no longer read, and however much React your visitor
+            downloads on their phone.
           </p>
           <p>
             One of these cards rendered in Node.js and arrived as finished HTML.
@@ -123,8 +124,8 @@ function BoundaryDemo() {
       meta={
         <>
           The error that sends everyone here is &ldquo;useState only works in a
-          Client Component&rdquo;. It is not a restriction. The server has no
-          clicks to listen for.
+          Client Component&rdquo;. The server isn&apos;t being difficult. It has
+          no clicks to listen for.
         </>
       }
       sourcePath="apps/web/app/[locale]/(playground)/boundary"
@@ -174,17 +175,16 @@ async function ShellDemo() {
           </p>
           <p>
             Then fetch what is actually cached now. The fingerprint moves twice,
-            not once. Expiring an entry and refilling it are separate events,
-            and the gap between them is the answer to the question you came here
-            with.
+            not once, and the gap between those two moves is where every
+            &ldquo;but I already revalidated it&rdquo; ticket lives.
           </p>
         </>
       }
       meta={
         <>
           &ldquo;Why is my page stale&rdquo; and &ldquo;why is my page
-          slow&rdquo; are one question read from opposite ends. Tune one and you
-          have chosen the other.
+          slow&rdquo; are one question read from opposite ends. Tune one and
+          you&apos;ve picked a side on the other, whether you meant to or not.
         </>
       }
       sourcePath="apps/web/app/[locale]/(playground)/shell"
@@ -222,10 +222,10 @@ function StreamDemo({ searchParams }: PageProps) {
       intro={
         <>
           <p>
-            It used to. Suspense ends the arrangement. The static shell ships
-            immediately, each slow part shows its fallback, and the server
-            streams finished HTML into place over the same response as each part
-            finishes. Nothing waits for everything.
+            It used to. Suspense ended that. The static shell ships immediately,
+            each slow part shows its fallback, and the server streams finished
+            HTML into place over the same response as each part finishes.
+            Nothing waits for everything.
           </p>
           <p>
             These three rows are slow on purpose. They resolve in delay order,
@@ -282,8 +282,8 @@ function MutationDemo() {
             You need a function. A Server Action lives on the server and plugs
             straight into a form&apos;s <InlineCode>action</InlineCode>: no
             endpoint to design, no fetch to write, no JSON contract to keep in
-            sync with itself. The form calls the function, the function mutates,
-            and Next.js re-renders the page around the result.
+            sync. The form calls the function, the function mutates, and Next.js
+            re-renders the page around the result.
           </p>
           <p>
             This one increments a counter held in an httpOnly cookie, read back
@@ -294,9 +294,11 @@ function MutationDemo() {
       }
       meta={
         <>
-          Somewhere a tutorial is still walking you through{" "}
-          <InlineCode>/api/increment</InlineCode>. Nothing in it was wrong. It
-          just stopped being necessary.
+          Somewhere a tutorial is teaching you to build{" "}
+          <InlineCode>/api/increment</InlineCode>. It will teach you to validate
+          the request body, handle the 405, and write a fetch wrapper with a
+          retry. All of it correct. All of it in service of adding one to a
+          number.
         </>
       }
       sourcePath="apps/web/app/[locale]/(playground)/mutation"
@@ -337,9 +339,9 @@ function ImageDemo() {
             every page you will ever publish.
           </p>
           <p>
-            Type a title and the server draws it. The same endpoint made the
-            link preview for this page, which is how you can check the claim
-            without taking our word for it.
+            Type a title and the server draws it. The same endpoint drew the
+            link preview for this page — paste the URL into Slack and check us
+            against it.
           </p>
         </>
       }

--- a/apps/web/app/api/og/title.ts
+++ b/apps/web/app/api/og/title.ts
@@ -1,4 +1,5 @@
-export const DEFAULT_OG_TITLE = "The live playground for Next.js & Vercel";
+export const DEFAULT_OG_TITLE =
+  "The unofficial live playground for Next.js & Vercel";
 export const MAX_TITLE_LENGTH = 70;
 
 /**

--- a/apps/web/app/confirmed/page.tsx
+++ b/apps/web/app/confirmed/page.tsx
@@ -1,12 +1,21 @@
 export default function Confirmed() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-900 p-4 text-center text-white">
-      <h1 className="mb-4 font-bold text-3xl">You&apos;re confirmed!</h1>
-      <p className="mb-4 max-w-md text-lg">
-        Thank you for confirming your email address. You are all set to receive
-        our weekly digest!
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background p-6 text-center">
+      <h1 className="font-display font-medium text-4xl text-foreground tracking-tight sm:text-5xl">
+        Confirmed.
+      </h1>
+      <p className="mt-6 max-w-md text-balance text-foreground/75 text-lg leading-8">
+        The next write-up lands in your inbox on Monday, alongside the exhibit
+        it belongs to. Until then, the playground is open.
       </p>
-      <p className="text-gray-400 text-lg">Eric</p>
+      <p className="mt-10">
+        <a
+          className="font-medium text-foreground underline decoration-ht-cyan-700/40 underline-offset-4 transition-colors hover:decoration-ht-cyan-700 dark:decoration-ht-cyan-300/40 dark:hover:decoration-ht-cyan-300"
+          href="/"
+        >
+          Back to the playground
+        </a>
+      </p>
     </div>
   );
 }

--- a/apps/web/app/styles.css
+++ b/apps/web/app/styles.css
@@ -126,6 +126,50 @@
     monospace;
 }
 
+/* ── Entrance choreography ──────────────────────────────────────────────
+   One movement, played two ways: the hero plays it on a clock, the sections
+   play it against their own position in the viewport. Neither depends on
+   JavaScript, so a failed hydration can never leave a section invisible. */
+@keyframes ht-rise {
+  from {
+    opacity: 0;
+    transform: translateY(0.75rem);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* The hero's load sequence — the thesis arrives one line at a time. Timed
+   animations are supported everywhere, so this runs for every visitor; each
+   element sets its own offset with --ht-delay. */
+@media (prefers-reduced-motion: no-preference) {
+  .ht-enter {
+    animation: ht-rise 700ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation-delay: var(--ht-delay, 0ms);
+  }
+}
+
+/* The same movement, scrubbed by scroll position instead. Wrapped in
+   @supports on purpose: a browser without scroll-driven animations skips the
+   whole rule and renders the content in place, so the fallback is the plain
+   page rather than an empty one.
+
+   This is also why the page root uses `overflow-x: clip` and not
+   `overflow: hidden` — `hidden` makes the root a scroll container, and
+   view() would then resolve against a box that never scrolls, leaving every
+   revealed element stuck at 0% forever. */
+@supports (animation-timeline: view()) {
+  @media (prefers-reduced-motion: no-preference) {
+    .ht-reveal {
+      animation: ht-rise linear both;
+      animation-timeline: view();
+      animation-range: entry 5% cover 18%;
+    }
+  }
+}
+
 /* Marketing keyframes */
 @keyframes rerender {
   0% {

--- a/apps/web/app/styles.css
+++ b/apps/web/app/styles.css
@@ -324,8 +324,3 @@
 
   @apply inline-block w-4 mr-8 text-muted-foreground text-right;
 }
-
-.shiki[title]:before {
-  content: attr(title);
-  @apply inline-block text-muted-foreground text-right mb-6 text-sm;
-}

--- a/apps/web/app/styles.css
+++ b/apps/web/app/styles.css
@@ -244,6 +244,31 @@
   }
 }
 
+/* Instrument display — a value that just changed announces itself once.
+   Same mount-keyed mechanism as .mirror-flash: the wrapper's React key is
+   the value's identity, so a new value remounts it and the wash runs. The
+   panel skips the class on the very first mount, so arriving at the page
+   doesn't read as a change. */
+@keyframes ht-land {
+  from {
+    background-color: rgb(245 158 11 / 0.12);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+
+.ht-land {
+  border-radius: 0.375rem;
+  animation: ht-land 900ms ease-out 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ht-land {
+    animation: none;
+  }
+}
+
 .highlighted-line {
   padding: 2px 8px 2px 0;
   border-radius: 12px;

--- a/docs/design.md
+++ b/docs/design.md
@@ -43,7 +43,10 @@ them all:
   aligned table, one narration caption. All describing text in one place.
 - **Deck — actions only.** Execution order, left to right. When a flow has
   real sequence, the controls diagram it (numbered steps, an arrow, the later
-  step dark until the earlier one fires).
+  step dark until the earlier one fires). A deck may end in a **result chip —
+  output, never input** — when the platform's own label for the sequence's
+  outcome is knowable by rule (exhibit 02: `revalidated · tag-based
+  deletion`, the badge Vercel files the refill under).
 - **Reference bar — the status bar every editor ends in.** The code drawer's
   disclosure left (source opens inside the chassis, native `<details>`, zero
   JS); `docs` and `source` links pinned right, positioned so clicking them
@@ -105,7 +108,15 @@ asides are already global via `DemoSection`.
 
 `next dev` lies about cache semantics (`updateTag` entries survive reloads
 that die on Vercel) — preview deploys are the truth-bench for anything
-touching `use cache`. The React DevTools extension throws spurious "The
+touching `use cache`.
+
+The verified badge sequence for the rebake flow on Vercel (2026-08-20,
+preview logs): `PRERENDER` on first visit → `HIT` → `BYPASS` for the action
+POST → `REVALIDATED`, reason "Tag-based deletion", for the request that
+refills. `updateTag` never produces `STALE` (that badge is
+stale-while-revalidate: `revalidateTag` or a lapsed `cacheLife` window), and
+the tag-deletion miss is labeled `REVALIDATED`, not `MISS`. Copy that names
+log badges must match this. The React DevTools extension throws spurious "The
 children should not have changed if we pass in the same set." errors on
 transition commits here; stacks resolving to `chrome-extension://…` are the
 extension's mirror desyncing, not an app bug.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,118 @@
+# The instrument design guide
+
+`voice.md`'s sibling: that guide governs what a visitor reads, this one
+governs what they see and press. It exists for the same reason — the design
+drifts, and it drifts toward decoration. Every element on a demo earns its
+place by answering one question: does this contribute to clarity? The page's
+feel is a developer environment, not a course platform. Engineer, not
+student.
+
+The audience is four people at once — an aspiring developer, a non-technical
+visitor, a junior, a senior — and they get **one experience legible at all
+levels, never per-level modes**. When a value needs to reach all four, encode
+it redundantly (two channels, one display), don't fork the interface.
+
+---
+
+## 1. The fixed grammar
+
+Every demo sits in the same chassis, zones in fixed positions — like a car's
+cockpit or an editor's panes, a visitor who has used one instrument has used
+them all:
+
+```
+┌──────────────────────────────────────────────┐
+│ ● live                        SLOW MOTION ⭘ │  chrome: state left, view right
+│                                              │
+│  bake #64f93b                                │  the specimen
+│  provenance rows · one narration caption     │
+├──────────────────────────────────────────────┤
+│ [ actions, in execution order ]              │  the deck
+├──────────────────────────────────────────────┤
+│ ▸ bake.ts + actions.ts       docs ↗ source ↗ │  reference bar
+└──────────────────────────────────────────────┘
+```
+
+- **Chrome, top-left — the state gauge.** `live` (cyan) at rest, `working`
+  (amber) while any server round trip is out. One in-flight signal per
+  instrument; this is it.
+- **Chrome, top-right — view controls.** Mode switches (slow motion) live in
+  the corner every editor keeps its view switches. Actions never live here.
+  Empty when a demo has no alternate view.
+- **Body — the specimen.** The observed value large, provenance rows as one
+  aligned table, one narration caption. All describing text in one place.
+- **Deck — actions only.** Execution order, left to right. When a flow has
+  real sequence, the controls diagram it (numbered steps, an arrow, the later
+  step dark until the earlier one fires).
+- **Reference bar — the status bar every editor ends in.** The code drawer's
+  disclosure left (source opens inside the chassis, native `<details>`, zero
+  JS); `docs` and `source` links pinned right, positioned so clicking them
+  never toggles the drawer. Row height mirrors the chrome header.
+
+What the grammar deliberately lacks: a panel label (the intro prose names the
+subject once) and a readout footer (the source in the drawer is the spec
+plate — a reader who wants identifiers is the reader who opens it).
+
+Outside the chassis: exhibit order rides in the eyebrow (`02 · caching &
+revalidation`) where engineers read identifiers — no watermark chapter
+numerals. Asides are set as `/* code comments */` in comment-gray mono,
+because that is what they are.
+
+## 2. Feedback
+
+Anything in flight says so three ways: the gauge flips to `working`, the
+specimen dims and pulses, and when the new value lands it takes one amber
+wash (`.ht-land` — key-remount, skips first paint, reduced-motion safe) and
+settles. No silent updates, ever.
+
+The React rule underneath: **client-owned state paints on the click frame;
+only the server sync lives in a transition.** A mode flip inside the same
+transition as its `router.refresh()` freezes the control until the round
+trip resolves. While the flipped view waits for the server, the copy must
+narrate the in-flight window honestly rather than claim a state the screen
+doesn't show (see the settling readout in `rebake-copy.ts`).
+
+## 3. Copy and demo co-evolve
+
+A demo that gains a capability can obsolete prose that was accurate the day
+it shipped — voice.md's three passes check a line against the panel *as it
+is*, so re-run them whenever the panel changes. (Evidence: voice.md §6,
+2026-08-19.)
+
+## 4. Migration state — 2026-08-19
+
+Exhibit 02 (the rebake demo) is the reference implementation. Exhibits 01,
+03, 04, 05 are on the legacy shape: `LivePanel` `label`/`readout` props,
+standalone `CodeBlock`s, the old links row under the panel. Migration is
+mostly mechanical per demo: compose a `ReferenceBar` with `CodeBlock
+variant="bar"` into the panel's `references` slot, drop the label and
+readout, move any mode switches to `viewControls`. The eyebrow and comment
+asides are already global via `DemoSection`.
+
+## 5. Banked
+
+- The bake fingerprint is six hex characters — literally a CSS color — and
+  the unlabeled `BakeSwatch` beside it renders that value. The discovery is
+  intentional; the digest write-up is where it gets spelled out.
+- Fruit/emoji hash encoding: rejected as primary (breaks instrument
+  discipline), held as a possible easter-egg layer.
+- Swatches in the machinery comparison rows: blocked until the string-based
+  width-reservation (`StableSlot`) grows a JSX-safe design.
+- Digest beats banked: the side-effect-runs-twice warning; the
+  swatch-is-the-hash reveal.
+
+## 6. Verification
+
+`next dev` lies about cache semantics (`updateTag` entries survive reloads
+that die on Vercel) — preview deploys are the truth-bench for anything
+touching `use cache`. The React DevTools extension throws spurious "The
+children should not have changed if we pass in the same set." errors on
+transition commits here; stacks resolving to `chrome-extension://…` are the
+extension's mirror desyncing, not an app bug.
+
+## 7. Keeping this current
+
+Same contract as voice.md §9: update on a decision that no rule here
+predicted, never on a schedule. §1–§3 are the rules and should grow
+reluctantly; §4–§6 are state and evidence — keep them dated, and correct
+them when the code moves.

--- a/docs/design.md
+++ b/docs/design.md
@@ -82,15 +82,25 @@ it shipped — voice.md's three passes check a line against the panel *as it
 is*, so re-run them whenever the panel changes. (Evidence: voice.md §6,
 2026-08-19.)
 
-## 4. Migration state — 2026-08-19
+## 4. Migration state — complete, 2026-08-20
 
-Exhibit 02 (the rebake demo) is the reference implementation. Exhibits 01,
-03, 04, 05 are on the legacy shape: `LivePanel` `label`/`readout` props,
-standalone `CodeBlock`s, the old links row under the panel. Migration is
-mostly mechanical per demo: compose a `ReferenceBar` with `CodeBlock
-variant="bar"` into the panel's `references` slot, drop the label and
-readout, move any mode switches to `viewControls`. The eyebrow and comment
-asides are already global via `DemoSection`.
+All five exhibits are on the grammar; the legacy shapes (`LivePanel`
+`label`/`readout`, standalone `CodeBlock`, `DemoSection`'s links row) are
+deleted, not deprecated. Judgment calls worth keeping:
+
+- **The specimen is not a control.** Exhibit 04's form and exhibit 01's
+  click-me button stay in the body: a form wired to a Server Action is the
+  lesson, and filing the subject under controls would misrepresent it. The
+  deck holds instrument controls only (03's rerun, 05's title form — which
+  drives the instrument rather than being it).
+- **Unique readout facts became narration lines**; redundant readouts were
+  cut without replacement (03, 04 — their facts live in the intro, the
+  captions, or the source).
+- **The gauge is wired where a client owns the panel** (02, 05). 03's
+  in-flight signal is carried by the row skeletons and the rerun button's
+  pending label instead — honest, but not the gauge; wire it if the stream
+  panel ever gains a client owner. 01 and 04 have no client round trip to
+  gauge (04's form works with JavaScript off, which is its point).
 
 ## 5. Banked
 

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -305,6 +305,21 @@ Number four is the one belief that arrives as advice rather than assumption,
 which is left deliberately: an API route is usually something a reviewer tells
 you to build, and converting it to a confession would cost the sting.
 
+From the exhibit-two redesign of 2026-08-19. Two rejections, neither
+anticipated by a rule above:
+
+| Standing | Shipped | Why |
+|---|---|---|
+| I cleared the cache, so the page is fresh now. | But I already revalidated it. | A belief that resolves its own drama doesn't hook — catch the believer after the belief has failed them |
+| The ritual: clear the cache, hard refresh, clear it again… (the aside) | In your app, the two renders behind one press would read the same database and agree… | Not wrong, not off-voice — obsoleted. The demo grew a slow-motion view that performs accidental refills, so an aside narrating them repeated the instrument |
+
+The first also showed where to look for the true utterance: it was already on
+the page, as the ticket line at the bottom of the intro. The second is a new
+failure mode the three passes don't catch on their own — a line that was
+accurate and in-voice the day it shipped, made redundant by the demo evolving
+underneath it. The passes check copy against the panel as it is, so run them
+again whenever the panel changes.
+
 ---
 
 ## 7. Time-hardening

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -40,6 +40,18 @@ then mechanism, then a pointer at the evidence — is his.
 > Safer than what? · You cleared it. Nothing refilled it. · Not any more. ·
 > You need a function. · You'll design one.
 
+### The walkthroughs — Brian Greene, *The Elegant Universe* (added 2026-08-19)
+
+For mechanism passages, where an intro must carry an abstraction. Escort the
+reader through it one step at a time: the concrete scene first, the abstract
+word only after its referent exists on screen, and the reader told where to
+look — watch, follow, notice. The scene extends the exhibit's own metaphor
+(the bake gets a shelf and an oven), never imports a foreign one. Take
+Greene's patience, not his scale: no cosmos, no wonder-hush, just the escort.
+The tell that this register is missing: two unintroduced terms meeting in one
+clause, asking the reader to solve a construction instead of watch a
+sequence.
+
 ### The asides — James Mickens, "The Night Watch", "The Slow Winter" (USENIX `;login:`)
 
 Steal the structure, never the voice — he is too distinctive to imitate without

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -81,6 +81,14 @@ not where the confidence leaks out.
 **The reader is competent.** They have shipped something they could not explain.
 So has everyone. That is the premise, not the accusation.
 
+**When a referent is vague, name it. Do not reach for a possessive.** "These
+answer back" has no antecedent, and the instinct is to fix it with "Our demos
+answer back" — but `our` repairs vagueness by asserting ownership, which drags
+the sentence into vendor register. "The demos below" repairs it by pointing,
+which costs nothing. This matters most next to a `we` that is being used for
+solidarity: "So have we" makes the narrator a fellow sufferer, and a possessive
+one sentence later turns the same `we` into the seller.
+
 ---
 
 ## 3. Do not

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -10,7 +10,13 @@ This document exists because the voice drifts. It drifts toward prose that is
 correct, defensible, and textureless — the register a language model produces
 when a sentence optimizes for being unobjectionable. Every rule below is derived
 from lines that were actually written for this site and actually accepted or
-rejected. Section 4 is the evidence.
+rejected. Section 6 is the evidence.
+
+**How to use it at each stage.** Drafting: start from §2, the lines that already
+work, and pattern-match. Editing: §4 and §5. Brainstorming: leave it closed.
+Its instinct is to narrow, and applied to raw ideas it kills the ones worth
+having before they are legible enough to defend. Bring it in when the idea has
+a shape and needs words, not before.
 
 ---
 
@@ -34,7 +40,7 @@ not wit.**
 **Mary Roach — *Stiff*, *Packing for Mars*.** The warmth. Funny about technical
 detail without ever being cruel about it, and curious in a way that makes the
 reader feel invited rather than tested. This slot originally read "Tufte", and
-the evidence in section 4 overruled it: austere declarative prose was proposed
+the evidence in section 6 overruled it: austere declarative prose was proposed
 repeatedly on this site and rejected every time.
 
 ### On Tufte
@@ -45,7 +51,61 @@ out cold. Use him on the panels, not the paragraphs.
 
 ---
 
-## 2. Techniques to reach for
+## 2. Lines that are right
+
+The rest of this document is a filter. This section is the generator. When
+starting from nothing, imitate these before consulting anything below.
+
+> **For developers who learn by poking things.**
+
+The whole voice in seven words. It names the audience by what they *do*, not by
+seniority or job title, and it does not flatter them. "Poking" is the site's
+verb — it appears in the hero, the CTA and the footer, and nothing else should
+replace it.
+
+> **Nothing on this page is a mockup. We checked twice.**
+
+The fourth wall, opened for exactly one clause and shut again. The joke is that
+the page knows it is marketing. Note what it does not do: it does not explain
+the joke, and it does not follow with a third sentence.
+
+> **I cleared the cache, so the page is fresh now.**
+
+An exhibit title. Speech, not a proposition — a thing a person says out loud,
+in the first person, in the tense they would say it. It is wrong, the reader has
+said it, and nothing labels either fact.
+
+> **Somewhere a tutorial is teaching you to build `/api/increment`. It will
+> teach you to validate the request body, handle the 405, and write a fetch
+> wrapper with a retry. All of it correct. All of it in service of adding one to
+> a number.**
+
+Texture is inventory. Three specific nouns do what no adjective could, and the
+punchline is carried entirely by the gap between the effort and the payload.
+
+> **cacheTag("landing-shell") · cacheLife("days") · one entry, shared by every
+> visitor**
+
+The instrument register, used in panel readouts and nowhere else: lowercase,
+middot-separated, real identifiers, no adjectives, no jokes. This is where Tufte
+lives. A readout that cannot be filled with true facts means the panel is not
+finished.
+
+> **The playground shows you the wall. The cohort gets you over it.**
+
+The one place a two-beat reversal is earned. §4 forbids aphorisms, and this
+looks like one — the difference is that both halves are literally true and the
+sentence is drawing a real distinction between two products rather than
+performing wisdom. Earn it this way or not at all.
+
+> **One email a week. Unsubscribing is one click, and it works the first time.**
+
+Warmth exactly where every other site is either cynical or corporate. It makes a
+small, checkable promise instead of a large unfalsifiable one.
+
+---
+
+## 3. Techniques to reach for
 
 **Texture is inventory.** When a line is correct but flat, the fix is almost
 never a better adjective. It is more specific nouns, accumulated until the point
@@ -98,7 +158,7 @@ one sentence later turns the same `we` into the seller.
 
 ---
 
-## 3. Do not
+## 4. Do not
 
 - **Label the confrontation.** No "MISCONCEPTION" eyebrow, no "here's what
   everyone gets wrong". The title is the confrontation.
@@ -120,7 +180,32 @@ one sentence later turns the same `we` into the seller.
 
 ---
 
-## 4. Evidence
+## 5. Editing: three passes
+
+Run these separately and in order. The Satori aside in §6 passed the first two
+and failed the third for weeks, because they were being checked at once.
+
+**Pass 1 — register.** Is it warm, plain and specific, or is it correct and
+flat? Flat is the default failure, not wrongness. Fix with nouns, not adjectives.
+
+**Pass 2 — truth.** Is every claim checkable against the panel directly below
+it? The page's entire authority is that it can be verified, so a line that
+overstates costs more than it earns. Read the readout and the panel copy
+together; they have contradicted each other before.
+
+**Pass 3 — subject.** Is the line about *this exhibit's argument*, or about
+something adjacent — the library underneath, a general truth about the web, a
+joke that would fit anywhere? Anything that would work equally well on another
+exhibit is not doing this exhibit's job.
+
+Then grep the draft for the tells: a two-beat reversal, three parallel clauses,
+"it's not X, it's Y", a compliment aimed at the reader, and any construction
+already used by a nearby exhibit. Reusing a signature move two sections apart
+reads as a formula even when each instance is good.
+
+---
+
+## 6. Evidence
 
 From the copy pass of 2026-08-15. Left column was proposed; right column is what
 shipped after review. The pattern is consistent enough to be a rule: **the
@@ -182,7 +267,7 @@ you to build, and converting it to a confession would cost the sting.
 
 ---
 
-## 5. Time-hardening
+## 7. Time-hardening
 
 Anchor copy on structural truths, not on current model or framework behaviour.
 A line that depends on how a specific model behaves this month is a line that
@@ -191,7 +276,7 @@ stale the Monday exhibit six ships, which is why it became "Still to build."
 
 ---
 
-## 6. Typography
+## 8. Typography
 
 Apostrophes in prose are **U+2019** (`’`), not the straight `'`. In JSX write
 `&rsquo;`, not `&apos;` — `&apos;` is U+0027 and renders straight. In TypeScript
@@ -206,3 +291,39 @@ with different marks. The landing page did exactly that until it was swept.
 **Code keeps straight quotes.** Anything inside `InlineCode`, a `CodeBlock`, or
 a readout quoting real source stays U+0027 — a smart quote in a code sample is
 a snippet that breaks when someone pastes it.
+
+---
+
+## 9. Keeping this current
+
+**Update on a novel rejection. Never on a schedule.**
+
+When a line gets cut, check whether a rule here already predicted it. If one
+did, the document worked — change nothing. Only a rejection that no existing
+rule anticipated earns an edit.
+
+Most rejections should produce no change at all. That is the system working, not
+neglect. A scheduled review is the wrong instrument, because a review with
+nothing to add still feels obliged to add something, and the failure mode of
+this document is not staleness — it is **bloat**. A guide that grows a rule per
+session becomes a guide nobody opens, which is worse than no guide, because it
+creates the impression the voice is handled.
+
+**The two halves have different rules.**
+
+- **§1–§5, the rules.** Stable, and capped at roughly a page. If §4 passes about
+  ten items, two of them are the same rule wearing different clothes — merge
+  them. Adding here should feel expensive.
+- **§6, the evidence.** Append-only and dated. Never edit an existing row. The
+  shipped column is a snapshot of that day, not a live citation; it drifted out
+  of sync with the page three times before this was written down, and chasing
+  the page is not worth the effort because the pattern is what the table is for.
+
+**Promote a line into §2 only when it has survived a review it could have lost.**
+That is what separates a canonical line from one that merely shipped.
+
+**When the site grows past the landing page**, keep one document. Per-surface
+guides drift apart, and the drift is invisible until two surfaces contradict
+each other in front of a reader. If a surface genuinely needs different rules —
+the digest email, the docs, the cohort materials — add a subsection here rather
+than a second file.

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -8,9 +8,13 @@ that label was tried and removed.
 
 This document exists because the voice drifts. It drifts toward prose that is
 correct, defensible, and textureless — the register a language model produces
-when a sentence optimizes for being unobjectionable. Every rule below is derived
-from lines that were actually written for this site and actually accepted or
-rejected. Section 6 is the evidence.
+when a sentence optimizes for being unobjectionable.
+
+Sections 3 through 8 are derived from lines actually written for this site and
+actually accepted or rejected; §6 is that evidence. **Section 1 is different.**
+The sources there were fitted to the pattern afterwards, so they describe what
+the page aims at rather than what it has achieved, and §1 ends with the gap
+between the two.
 
 **How to use it at each stage.** Drafting: start from §2, the lines that already
 work, and pattern-match. Editing: §4 and §5. Brainstorming: leave it closed.
@@ -20,34 +24,73 @@ a shape and needs words, not before.
 
 ---
 
-## 1. The three sources
+## 1. Four registers and one stance
 
-**Paul Ford — "What Is Code?" (Bloomberg Businessweek, 2015).** The spine.
-Long, genuinely technical, funny, second person, quietly brutal about the
-reader's assumptions and never wrong. His load-bearing move is that the
+The page runs four registers. Each owns specific elements and has its own
+source. A fifth name, Ford, is not a register at all — it is a constraint on all
+four.
+
+### The spine — Matthew Butterick, *Practical Typography*
+
+The exhibit intros. Opinionated technical instruction: states that you are
+wrong, explains exactly why, never hedges, never digresses, and does not soften
+the correction with charm. The shape the intros already have — a rebuttal beat,
+then mechanism, then a pointer at the evidence — is his.
+
+> Safer than what? · You cleared it. Nothing refilled it. · Not any more. ·
+> You need a function. · You'll design one.
+
+### The asides — James Mickens, "The Night Watch", "The Slow Winter" (USENIX `;login:`)
+
+Steal the structure, never the voice — he is too distinctive to imitate without
+it reading as impersonation. The structure: set up a received platitude, then
+describe what actually happens in escalating operational detail until the
+platitude collapses under its own specifics. **Texture is inventory, not wit.**
+
+### The frame — Mary Roach, *Stiff*, *Packing for Mars*
+
+The hero, cohort, digest and FAQ. Funny about technical detail without ever
+being cruel about it, curious in a way that makes the reader feel invited rather
+than tested. This is where the page is allowed to be warm without being soft.
+
+### The instrument — Edward Tufte
+
+Panel readouts and labels, and nothing else. Lowercase, middot-separated, real
+identifiers, no adjectives, no jokes; every mark earning its place. In the
+paragraphs this register comes out cold, and §6 records it being proposed there
+and rejected every time.
+
+### The stance — Paul Ford, "What Is Code?" (Bloomberg Businessweek, 2015)
+
+Not a register. A constraint on all four. Ford's load-bearing move is that the
 confrontation includes the narrator — he diagnoses the industry's impostor
-syndrome and puts himself in the diagnosis rather than above it. The moment
-hasToggle is exempt from its own verdict it becomes smug, and the misconception
-frame stops working.
+syndrome and puts himself inside the diagnosis rather than above it.
 
-**James Mickens — "The Night Watch", "The Slow Winter" (USENIX `;login:`).**
-The asides. Steal the structure, never the voice — he is too distinctive to
-imitate without it reading as impersonation. The structure: set up a received
-platitude, then describe what actually happens in escalating operational detail
-until the platitude collapses under its own specifics. **Texture is inventory,
-not wit.**
+This matters more here than it does for him. The misconception frame works by
+quoting a belief the reader holds, and a quotation delivered from above is an
+accusation. The moment hasToggle is exempt from its own verdict, the whole
+device turns smug.
 
-**Mary Roach — *Stiff*, *Packing for Mars*.** The warmth. Funny about technical
-detail without ever being cruel about it, and curious in a way that makes the
-reader feel invited rather than tested. This slot originally read "Tufte", and
-the evidence in section 6 overruled it: austere declarative prose was proposed
-repeatedly on this site and rejected every time.
+### Where the page falls short of this — audited 2026-08-16
 
-### On Tufte
+These four are targets. The landing page does not fully hit them yet, and this
+list exists so nobody drafts against §1 believing it is a description:
 
-Tufte is the right instinct for the *demos* — contempt for decoration, every
-mark earning its place — and the wrong instinct for the *prose*, where it comes
-out cold. Use him on the panels, not the paragraphs.
+- **The stance is nearly absent.** It appears once, in the hero footnote ("So
+  have we"). Across all five exhibit intros, first-person plural occurs once and
+  it is a pointer rather than an admission. The spine currently diagnoses
+  without ever joining.
+- **Mickens covers two of five asides, and they are adjacent.** Exhibits four
+  and five run the same inventory move back to back, which is exactly the
+  repetition §5 warns about. Asides one, two and three are understatement,
+  aphorism and metaphor respectively.
+- **Roach does not reach the exhibits.** The warmth stops at the frame. Intro
+  three contains no second person and no joke, which makes it measurably the
+  flattest prose on the page — a structural gap, not a word-choice one.
+- **One line inverts the stance.** "See? We told you what we're selling. Most
+  landing pages hide that part." awards the narrator a point, and is the only
+  line that punches at a third party instead of at a belief the reader holds.
+- **Aside two is the closest surviving thing to an aphorism**, which §4 forbids.
 
 ---
 

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -125,20 +125,37 @@ time.**
 | An answer you read is borrowed. An answer you ran is yours. | For developers who learn by poking things. | Aphorism lost to plain speech |
 | Nothing here is a screenshot. Every panel is the feature itself, running. | Nothing on this page is a mockup. We checked twice. | Severity lost to the fourth-wall wink |
 | Run the first one | Start poking | Same |
-| It looks like CSS. Satori reads flexbox and nothing else — grid is not approximated, it is refused. | The fine print: it looks like CSS, but the renderer (Satori) only understands flexbox. Grid users will be shown the door, politely, at build time. | Austere correction lost to comic understatement |
+| It looks like CSS. Satori reads flexbox and nothing else — grid is not approximated, it is refused. | The fine print: it looks like CSS, but the renderer (Satori) only understands flexbox. Grid users will be shown the door, politely, the moment the route runs. | Austere correction lost to comic understatement |
 | The playground shows you the wall. | Some things move faster with a coach. | Clever reversal lost to the plain statement |
 | AI produces the artifact. You hold the meaning. | You get the playground and the making-of. | Portent lost to concreteness |
 | Unsubscribing is one click, and nobody asks why. | …and it works the first time. | Cynical lost to warm |
 | `MISCONCEPTION` eyebrow, red, above every title | (removed; topic restored) | Announced the joke before the title landed |
 
-Titles that were rewritten to state a belief more plainly, which is the frame
-working correctly:
+That Satori line originally ended "at build time", which was simply false —
+`/api/og` is a route handler taking a query param, so it fails when the route
+runs, as the panel's own readout says two lines below it. **A good joke does not
+buy an inaccurate claim.** The wording changed; the joke did not have to.
 
-| Before | After |
-|---|---|
-| This page was baked before you arrived. | I cleared the cache, so the page is fresh now. |
-| The page refused to wait. | Nothing renders until the slowest part is ready. |
-| An image that didn't exist a second ago. | Every link preview is an image someone made by hand. |
+Titles, which are the frame working correctly. Each one is a sentence a
+developer has actually said, and each intro answers it in the first few words:
+
+| Before | Shipped | Intro opens |
+|---|---|---|
+| Two components walk into a page. | I'll put "use client" on it, to be safe. | Safer than what? |
+| This page was baked before you arrived. | I cleared the cache, so the page is fresh now. | You cleared it. Nothing refilled it. |
+| The page refused to wait. | I'll fetch it all first, then render. | Not any more. |
+| A form with no API route. | You need an API route for that. | You need a function. |
+| An image that didn't exist a second ago. | I'll need to design a card for every page. | You'll design one. |
+
+Two rules fell out of writing these. **A belief has to be speech, not a
+proposition** — "Nothing renders until the slowest part is ready" is merely
+true, where "I'll fetch it all first, then render" is something a person says.
+And **the intro answers the belief in its opening beat**, before any
+explanation starts.
+
+Number four is the one belief that arrives as advice rather than assumption,
+which is left deliberately: an API route is usually something a reviewer tells
+you to build, and converting it to a confession would cost the sting.
 
 ---
 

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -148,3 +148,21 @@ Anchor copy on structural truths, not on current model or framework behaviour.
 A line that depends on how a specific model behaves this month is a line that
 will be wrong by a release. Same for counts: "Five exhibits. Dozens to go." goes
 stale the Monday exhibit six ships, which is why it became "Still to build."
+
+---
+
+## 6. Typography
+
+Apostrophes in prose are **U+2019** (`’`), not the straight `'`. In JSX write
+`&rsquo;`, not `&apos;` — `&apos;` is U+0027 and renders straight. In TypeScript
+strings that reach the page (panel labels, button text, captions) write the
+curly character directly.
+
+This is not fussiness. The page mixes JSX text with copy held in string props
+and arrays, and the two escape differently, so a page can end up rendering
+`You'll design one` three lines from `I’ll need to design a card for every page`
+with different marks. The landing page did exactly that until it was swept.
+
+**Code keeps straight quotes.** Anything inside `InlineCode`, a `CodeBlock`, or
+a readout quoting real source stays U+0027 — a smart quote in a code sample is
+a snippet that breaks when someone pastes it.

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -1,0 +1,142 @@
+# The hasToggle voice
+
+Clear, funny, and confrontational — with the confrontation **covert**. The
+exhibit titles state a belief the reader holds. That is the whole confrontation.
+Nothing in the surrounding prose needs to press the point, and a label that
+announces it ("MISCONCEPTION" in red above the title) kills it, which is why
+that label was tried and removed.
+
+This document exists because the voice drifts. It drifts toward prose that is
+correct, defensible, and textureless — the register a language model produces
+when a sentence optimizes for being unobjectionable. Every rule below is derived
+from lines that were actually written for this site and actually accepted or
+rejected. Section 4 is the evidence.
+
+---
+
+## 1. The three sources
+
+**Paul Ford — "What Is Code?" (Bloomberg Businessweek, 2015).** The spine.
+Long, genuinely technical, funny, second person, quietly brutal about the
+reader's assumptions and never wrong. His load-bearing move is that the
+confrontation includes the narrator — he diagnoses the industry's impostor
+syndrome and puts himself in the diagnosis rather than above it. The moment
+hasToggle is exempt from its own verdict it becomes smug, and the misconception
+frame stops working.
+
+**James Mickens — "The Night Watch", "The Slow Winter" (USENIX `;login:`).**
+The asides. Steal the structure, never the voice — he is too distinctive to
+imitate without it reading as impersonation. The structure: set up a received
+platitude, then describe what actually happens in escalating operational detail
+until the platitude collapses under its own specifics. **Texture is inventory,
+not wit.**
+
+**Mary Roach — *Stiff*, *Packing for Mars*.** The warmth. Funny about technical
+detail without ever being cruel about it, and curious in a way that makes the
+reader feel invited rather than tested. This slot originally read "Tufte", and
+the evidence in section 4 overruled it: austere declarative prose was proposed
+repeatedly on this site and rejected every time.
+
+### On Tufte
+
+Tufte is the right instinct for the *demos* — contempt for decoration, every
+mark earning its place — and the wrong instinct for the *prose*, where it comes
+out cold. Use him on the panels, not the paragraphs.
+
+---
+
+## 2. Techniques to reach for
+
+**Texture is inventory.** When a line is correct but flat, the fix is almost
+never a better adjective. It is more specific nouns, accumulated until the point
+arrives on its own.
+
+> Somewhere a tutorial is still walking you through `/api/increment`. Nothing in
+> it was wrong. It just stopped being necessary.
+
+becomes
+
+> Somewhere a tutorial is teaching you to build `/api/increment`. It will teach
+> you to validate the request body, handle the 405, and write a fetch wrapper
+> with a retry. All of it correct. All of it in service of adding one to a
+> number.
+
+Nothing was added but detail. The joke arrived by itself.
+
+**Comic understatement over severity.** The deflating aside lands; the austere
+correction does not. "Grid users will be shown the door, politely, at build
+time" survived. "Grid is not approximated, it is refused" was rejected.
+
+**Break the fourth wall, briefly.** The `//` asides are allowed to know they are
+marketing. "We checked twice." "You knew this was coming. We both did." One
+clause, then get out.
+
+**The asterisk substantiates. It does not deflate.** A footnote that walks back
+the line above it costs the page the one thing it has — a headline you can
+trust. So the headline makes the claim at full strength, and the asterisk hands
+over the receipts: what to press, what to read, how to check. Same for "the fine
+print:" openers on the demo asides. The small type is where the evidence lives,
+not where the confidence leaks out.
+
+**The reader is competent.** They have shipped something they could not explain.
+So has everyone. That is the premise, not the accusation.
+
+---
+
+## 3. Do not
+
+- **Label the confrontation.** No "MISCONCEPTION" eyebrow, no "here's what
+  everyone gets wrong". The title is the confrontation.
+- **Write aphorisms.** "An answer you read is borrowed. An answer you ran is
+  yours." Rejected. Portentous two-beat reversals read as fortune cookies and
+  are the single most common drift on this site.
+- **Reach for Vonnegut.** Short sentence, then a shrug. This is now the default
+  register a model reaches for when asked to sound literary. Using it makes the
+  problem worse.
+- **Stack DFW footnotes.** There is already a footnote layer, and the technical
+  claims have to stay checkable.
+- **Use the em-dash triplet.** "…what can read secrets, what can hold state,
+  what ships JavaScript." Three parallel clauses in a row is the tell.
+- **Flatter the reader.** "The fact that you're reading the fine print says
+  something about you. Something good." Cut on sight.
+- **Say "it's not X, it's Y"** unless X is a thing someone actually said.
+- **Claim more than the panel proves.** The page's authority is that every
+  sentence is checkable. One inflated line costs all of them.
+
+---
+
+## 4. Evidence
+
+From the copy pass of 2026-08-15. Left column was proposed; right column is what
+shipped after review. The pattern is consistent enough to be a rule: **the
+warmer, plainer, more playful option won every time, and severity lost every
+time.**
+
+| Proposed | Shipped | Why |
+|---|---|---|
+| An answer you read is borrowed. An answer you ran is yours. | For developers who learn by poking things. | Aphorism lost to plain speech |
+| Nothing here is a screenshot. Every panel is the feature itself, running. | Nothing on this page is a mockup. We checked twice. | Severity lost to the fourth-wall wink |
+| Run the first one | Start poking | Same |
+| It looks like CSS. Satori reads flexbox and nothing else — grid is not approximated, it is refused. | The fine print: it looks like CSS, but the renderer (Satori) only understands flexbox. Grid users will be shown the door, politely, at build time. | Austere correction lost to comic understatement |
+| The playground shows you the wall. | Some things move faster with a coach. | Clever reversal lost to the plain statement |
+| AI produces the artifact. You hold the meaning. | You get the playground and the making-of. | Portent lost to concreteness |
+| Unsubscribing is one click, and nobody asks why. | …and it works the first time. | Cynical lost to warm |
+| `MISCONCEPTION` eyebrow, red, above every title | (removed; topic restored) | Announced the joke before the title landed |
+
+Titles that were rewritten to state a belief more plainly, which is the frame
+working correctly:
+
+| Before | After |
+|---|---|
+| This page was baked before you arrived. | I cleared the cache, so the page is fresh now. |
+| The page refused to wait. | Nothing renders until the slowest part is ready. |
+| An image that didn't exist a second ago. | Every link preview is an image someone made by hand. |
+
+---
+
+## 5. Time-hardening
+
+Anchor copy on structural truths, not on current model or framework behaviour.
+A line that depends on how a specific model behaves this month is a line that
+will be wrong by a release. Same for counts: "Five exhibits. Dozens to go." goes
+stale the Monday exhibit six ships, which is why it became "Still to build."

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -71,26 +71,23 @@ quoting a belief the reader holds, and a quotation delivered from above is an
 accusation. The moment hasToggle is exempt from its own verdict, the whole
 device turns smug.
 
-### Where the page falls short of this — audited 2026-08-16
+### Audit — 2026-08-16
 
-These four are targets. The landing page does not fully hit them yet, and this
-list exists so nobody drafts against §1 believing it is a description:
+These four are targets, not a description. The landing page was audited against
+them and five gaps were found and closed the same day:
 
-- **The stance is nearly absent.** It appears once, in the hero footnote ("So
-  have we"). Across all five exhibit intros, first-person plural occurs once and
-  it is a pointer rather than an admission. The spine currently diagnoses
-  without ever joining.
-- **Mickens covers two of five asides, and they are adjacent.** Exhibits four
-  and five run the same inventory move back to back, which is exactly the
-  repetition §5 warns about. Asides one, two and three are understatement,
-  aphorism and metaphor respectively.
-- **Roach does not reach the exhibits.** The warmth stops at the frame. Intro
-  three contains no second person and no joke, which makes it measurably the
-  flattest prose on the page — a structural gap, not a word-choice one.
-- **One line inverts the stance.** "See? We told you what we're selling. Most
-  landing pages hide that part." awards the narrator a point, and is the only
-  line that punches at a third party instead of at a belief the reader holds.
-- **Aside two is the closest surviving thing to an aphorism**, which §4 forbids.
+| Gap | Closed by |
+|---|---|
+| The stance appeared once on the whole page, in the hero footnote. All five exhibit intros diagnosed without ever joining. | Exhibit one now opens "We reached for it the same way, for about a year, before anyone made us say what it was protecting against." |
+| Mickens covered two of five asides and they were **adjacent** — four and five ran the same inventory move back to back, the repetition §5 warns about. | Aside two becomes the inventory; aside five becomes warmth. The asides now alternate rather than doubling. |
+| Roach never reached the exhibits. Intro three had no second person and no joke — the flattest prose on the page, structurally rather than by word choice. | Intro three now admits the delays are hardcoded, which is both the warm beat and a second instance of the stance. |
+| "See? We told you what we're selling. Most landing pages hide that part." inverted the stance — the narrator awarding itself a point, and the only line punching at a third party. | Replaced with "Now you know what's being sold. Weigh the rest of the page against that." Judgment handed to the reader instead of claimed. |
+| Aside two was the closest surviving thing to the aphorism §4 forbids. | Same edit as row two. |
+
+**Re-audit before assuming this holds.** The counts that produced it are cheap
+to reproduce: first-person plural per intro, register per aside, second-person
+density per section. A register drifting back is invisible line by line and
+obvious in aggregate, which is the only reason it was caught.
 
 ---
 

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -332,6 +332,13 @@ accurate and in-voice the day it shipped, made redundant by the demo evolving
 underneath it. The passes check copy against the panel as it is, so run them
 again whenever the panel changes.
 
+From the hero footnote, 2026-08-20. Two rejections in one line, both novel:
+
+| Standing | Shipped | Why |
+|---|---|---|
+| You've opened a "live demo" that turned out to be an animated GIF. So have we. | (cut) | A manufactured shared experience — plausible, not lived. Second bite of the same failure as the exhibit-two title: invented relatability reads as marketing doing an impression of empathy. It also punched at third parties, which §1's audit already banned once |
+| Two sentences of replacement prose | everything below runs · the source is in every panel · even the prompts are public | The container sets the register. A hover card is a readout, not a paragraph — prose in a tooltip is the wrong instrument no matter how good the prose is |
+
 ---
 
 ## 7. Time-hardening

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -78,6 +78,13 @@ over the receipts: what to press, what to read, how to check. Same for "the fine
 print:" openers on the demo asides. The small type is where the evidence lives,
 not where the confidence leaks out.
 
+**The aside lands on the exhibit's topic, not on its dependencies.** Demo five
+spent its aside on Satori's missing grid support — true, useful, and about the
+rendering library rather than about generating images from code. A constraint of
+the thing underneath is not the argument. Implementation limits belong in the
+panel readout, where they read as specification; the aside is for what the
+exhibit is actually claiming.
+
 **The reader is competent.** They have shipped something they could not explain.
 So has everyone. That is the premise, not the accusation.
 
@@ -131,10 +138,26 @@ time.**
 | Unsubscribing is one click, and nobody asks why. | …and it works the first time. | Cynical lost to warm |
 | `MISCONCEPTION` eyebrow, red, above every title | (removed; topic restored) | Announced the joke before the title landed |
 
-That Satori line originally ended "at build time", which was simply false —
-`/api/og` is a route handler taking a query param, so it fails when the route
-runs, as the panel's own readout says two lines below it. **A good joke does not
-buy an inaccurate claim.** The wording changed; the joke did not have to.
+The right column is a snapshot of what shipped on that date, not a live citation
+— several of these lines have been revised since, and the pattern is the point.
+
+The Satori row is worth following all the way through, because it failed three
+different ways in three passes:
+
+1. The austere version — "grid is not approximated, it is refused" — lost to
+   comic understatement. That is the rule this table exists to show.
+2. The understated version ended "at build time", which was **false**. `/api/og`
+   is a route handler taking a query param, so it fails when the route runs, as
+   the panel's own readout says two lines below. A good joke does not buy an
+   inaccurate claim.
+3. The corrected version was still about the wrong subject. Satori's flexbox
+   limit is a fact about the rendering library, not about generating images
+   from code, so the aside was spending the exhibit's best line on a
+   dependency. It now itemises the design workflow the exhibit retires, and the
+   flexbox constraint moved to the panel readout.
+
+Being funny, then being accurate, then being about the right thing are three
+separate edits, and a line can pass the first two while failing the third.
 
 Titles, which are the frame working correctly. Each one is a sentence a
 developer has actually said, and each intro answers it in the first few words:


### PR DESCRIPTION
The landing page gets one voice and one instrument. The branch ran in two arcs: first the voice — restored, written down in `docs/voice.md`, applied to every section. Then the exhibits themselves: exhibit two rebuilt around the one gap developers actually meet in their logs, a fixed design grammar extracted from that rebuild into `docs/design.md`, and every exhibit migrated onto it. Project knowledge now lives in the repo — the two guides are the deliverable as much as the page is.

<details>
<summary><strong>Part I — the voice (first six commits, original description)</strong></summary>

The landing copy had drifted into a chummy, AI-flavoured register. This restores the voice the site had before the playground rewrite, writes it down so it stops drifting, applies it to every section, fixes a section that sat off the page's left edge, and adds a small motion layer.

Six commits, each independently reviewable.

## 1. The misconception frame — `2c799a6`

Each exhibit opens with a belief a developer has actually said, and the running panel answers it. This isn't a new idea — it's what the product already runs on. `misconception` is a field in `packages/database/types.ts`, and the digest email leads with `Misconception: "…"`. The page and the Monday email now use the same device.

The eyebrow stays the **topic** (`caching & revalidation`), not a `MISCONCEPTION` label: labelling it announced the point before the title could land. `DemoSection`'s `hook` prop is renamed `belief`, and the rail is now just the number.

### Alignment

Roadmap was flush to the container edge while the exhibits and cohort sat behind a 7rem rail. It now shares that rail via an empty spacer. Its title also loses the hardcoded count, which would go stale the Monday exhibit six ships.

### Motion

One movement — `ht-rise`, fade + 12px rise on `cubic-bezier(.16,1,.3,1)` — played two ways: on a clock for the hero load sequence, scrubbed by scroll position for section reveals. Plus a hairline that draws in under the Contents links and a warming border on the live panels.

**No JavaScript is involved.** The reveals use `animation-timeline: view()` behind `@supports`, so browsers without scroll-driven animations skip the rule and render the page in place rather than risking a blank section.

That required the page root to move from `overflow-hidden` to `overflow-x-clip`. `overflow: hidden` makes the root a scroll container, and `view()` would then resolve against a box that never scrolls — pinning every revealed element at 0% forever.

## 2. The voice, written down — `09ba61b`

Adds `docs/voice.md`. The voice kept drifting because it lived in one person's head and got re-derived every session.

It fixes three sources — **Paul Ford** for the spine (confrontation that includes the narrator), **James Mickens** for the asides (texture is inventory, not wit), **Mary Roach** for the warmth — plus the techniques and a do-not list.

Section 4 is the part that earns its place: a table of lines *proposed* against lines *shipped*, taken from this branch's own review. The pattern is consistent enough to be a rule — the warmer, plainer, more playful option won every time and severity lost every time — which is why the guide names Roach where an earlier draft had Tufte. Tufte stays, but for the panels rather than the paragraphs.

**Drops the Pratchett attribution entirely.** It was only ever applied to one device, in one spec covering deleted code. The rule that replaces it suits a page whose whole thesis is that you can check it: *the asterisk substantiates, it does not deflate.*

The hero footnote is rewritten to that rule, and both render sites now share `HeroFootnoteBody` — the marker and text had been duplicated verbatim between the desktop hover card and the mobile block.

## 3. Applying it to the exhibit prose — `80556e5`

The headings and asides had the voice; the paragraphs under them didn't.

| before | after |
|---|---|
| You spend the secrets, the direct data access, and the JavaScript your visitor now downloads. | You pay with the database call you can no longer make from here, the API key you can no longer read, and however much React your visitor downloads on their phone. |
| Nothing in it was wrong. It just stopped being necessary. | It will teach you to validate the request body, handle the 405, and write a fetch wrapper with a retry. All of it correct. All of it in service of adding one to a number. |
| It is not a restriction. | The server isn't being difficult. |
| Expiring an entry and refilling it are separate events _(repeated from paragraph one)_ | …the gap between those two moves is where every "but I already revalidated it" ticket lives. |
| something new to press | something new to poke |

Also adds the rule that came out of reviewing the hero footnote: **when a referent is vague, name it rather than reaching for a possessive.** "Our demos" repairs vagueness by asserting ownership and lands in vendor register; "the demos below" repairs it by pointing.

## 4. The sections that were left alone — `02dc9fe`

Hero metadata, the five beliefs, the Satori aside, the cohort, the FAQ.

| where | before | after |
|---|---|---|
| Belief 03 | Nothing renders until the slowest part is ready. | I'll fetch it all first, then render. |
| Belief 05 | Every link preview is an image someone made by hand. | I'll need to design a card for every page. |
| 02 intro | Clearing it and refilling it are two different events… | **You cleared it. Nothing refilled it.** Those are two different events… |
| Satori aside | shown the door, politely, **at build time**. | shown the door, politely, **the moment the route runs**. |
| Cohort | …on exactly these topics, AI workflow included. | …with the same AI workflow that built this page. |
| FAQ heading | Your questions answered. | Before you poke anything. |
| FAQ, how it's built | …That division of labor is the actual curriculum. | …Someone still has to decide what ships, and that part hasn't been automated. |
| Meta description | **Five things** developers believe… | Every exhibit takes something developers are sure about… |

Three findings behind those:

**The Satori aside was factually wrong.** It said grid gets refused "at build time". `/api/og` is a route handler taking a `title` query param — it renders per request, and the panel's own readout two lines below says *"rendered per request, cached by nobody"*. The page contradicted itself. The joke survives; the claim is now true.

**The beliefs were in three grammatical registers** — first-person confession, impersonal proposition, advice received. 03 and 05 become things a developer actually says. Belief 04 stays as advice received on purpose: an API route is usually something a reviewer tells you to build, and converting it would cost the sting.

**Every intro now opens with a rebuttal beat** — *Safer than what? / You cleared it. Nothing refilled it. / Not any more. / You need a function. / You'll design one.* Only 02 was missing one.

Also deduplicates "what it shows, why it matters, when to reach for it", which was running verbatim in both the digest and the FAQ.

## 5. One apostrophe — `38ad4ba`

The page rendered 18 straight apostrophes and 9 curly ones. JSX text escaped as `&apos;` (U+0027) while copy held in string props and arrays carried the literal U+2019, so *"You'll design one"* sat three lines from *"I'll need to design a card for every page"* with different marks.

All prose is now U+2019. **Code is deliberately untouched** — a smart quote inside a `CodeBlock` or `InlineCode` is a snippet that breaks when someone pastes it, and this page invites pasting. Recorded as §6 of the guide.

## 6. Re-syncing the guide — `d8b8fb5`

Shipping the guide exposed the guide: §4 cited three lines as shipped that had since been rewritten, including the Satori line still quoted with its `at build time` error. A voice guide that misquotes the page is doing the exact thing it forbids.

The titles table now lists all five beliefs with each intro's opening beat, which let two implicit rules get written down: **a belief must be speech, not a proposition**, and **the intro answers the belief before any explanation starts**.

## Verification

- Playwright at 1440px and 390px, light and dark: after a full scroll-through, **zero** `.ht-reveal` / `.ht-enter` elements below full opacity. Under `prefers-reduced-motion: reduce`, everything is fully visible with no scrolling at all.
- Prose checked against the **prerendered HTML**, not the source. This caught a doubled space where three `InlineCode` chips met a `&#32;` the JSX line-join had already supplied, and confirmed 0 straight apostrophes in prose / 0 curly ones in code.
- Every line the guide quotes as live is grepped against the actual source — all 15 agree.
- Biome clean, 189/189 tests pass, typecheck clean for app files.
- `rebake-copy.test.ts` updated for the two caption strings it pins.

## Not included

`apps/web/AGENTS.md` and `apps/web/CLAUDE.md` are untracked in the working tree. They're generated by `next dev` and predate this work, so they're left out.


</details>

## Part II — the exhibits

### Unofficial, where the page introduces itself

The kicker, `<title>`, and default OG card now read "The unofficial live playground for Next.js & Vercel"; a new FAQ ("Is this official?") turns the disclaimer into the product's advantage, and the footer carries the trademark line. The roadmap grew from ten items to seventeen (navigation, metadata, optimistic UI, i18n, view transitions, feature flags, web vitals) and dropped the stale wording ("at scale", the retired KV SKU). `/confirmed` — the digest landing — moved onto design tokens and the house voice.

### Exhibit two, rebuilt around the gap

The mechanism first: `updateTag`'s expiry is a watermark stamped after the render that triggered it, so the action's own render is cached for nobody (verified against the Next 16.3.0 source and PR #364's production measurements). The exhibit now teaches that honestly, in layers:

- **Two views, one switch.** The demo opens with the fused flow real apps ship — one press, expire and refill chained — and a `slow motion` switch splits it into the machinery: numbered steps (`1 Expire the entry → 2 Ask for the page`), captions that name their APIs at the moment they fire, and a type-encoded invariant that the simple view never rests on an unanswered expiry (flipping the switch off mid-gap settles it with a refresh).
- **Grounded in the reader's logs.** The belief became the binary everyone carries in — *"It's either cached or it isn't."* — and the payoff lands on the badges Vercel actually files: the refill request logs `REVALIDATED`, reason `tag-based deletion` (verified in the preview's runtime logs), with `STALE` correctly attributed to the soft path. The machinery deck completes with that badge as its output chip. The earlier draft claimed a MISS and dangled STALE; the logs falsified both, and `design.md` §6 now pins the verified sequence so copy can't drift back.
- **The fingerprint is the literal value.** Bake ids are six hex characters — a CSS color by construction — and an unlabeled swatch renders exactly that value beside the hash (`#64f93b` → `rgb(100, 249, 59)`, byte-verified). One display, two channels; the discovery is intentional.
- **Honesty gates.** The ask button stays dark until the private render has landed (asking earlier captured the old shared fingerprint and made the comparison lie); the settling readout covers the toggle-off window; the in-flight readout is held during a fused press so the hook caption arrives with the new fingerprint, not before it.

### The instrument grammar, page-wide

`docs/design.md` (voice.md's sibling) fixes the chassis every demo sits in: state gauge top-left (`live`/`working`), view controls top-right, specimen and narration in the body, actions-only deck, and a reference bar — code drawer opening inside the chassis, docs/source links pinned right. Feedback is a contract: gauge flips, specimen dims and pulses, one amber wash when a value lands; client-owned state paints on the click frame and only server sync lives in transitions. All five exhibits are migrated; the legacy shapes (`label`/`readout` props, standalone code frames, the links row) are deleted, not deprecated. Exhibit order rides in the eyebrow; asides render as the `/* code comments */` they are; the intros take the Greene walkthrough register (concrete scene first, the term after its referent — hydration named after the waking, fallbacks pointed at the gray placeholders).

### Page furniture

- **Sticky contents.** The contents row moved out of the hero, rides the exhibits' own rail grid (label in the gutter, first link on the content edge), pins while the visitor is among the exhibits, and releases after demo 05 — sticky bounds, zero JavaScript. Demo 02 is "The cache" now: wayfinding speaks the reader's vocabulary, not the house metaphor's.
- **Receipts.** The checkpoints repo went public and the page links it (roadmap aside, built-FAQ); "repo is on GitHub" links where it says; the footer's social row leads with the octocat. The hero footnote became the readout it always was: `everything below runs · the source is in every panel · even the prompts are public`.
- **Small honesty fixes.** The streamed hero line pulses while pending and lands with the amber wash; the cohort CTA focuses the digest email field and works on every press (same-hash links go dead after one).

## Verification

- 198 web tests, Biome, and per-workspace typecheck green at every push (one build break mid-branch — a test literal lagging a type change — fixed in `159743f1`; `bun test` alone is not the gate, `tsc` is part of it).
- Every interaction browser-verified per change at desktop and mobile widths: all rebake paths including toggle-off-mid-gap, the gauge flips, the landing washes, sticky pin/release/anchor offsets, the CTA double-press.
- Cache semantics verified where they are true: `next dev`'s tiered handler hides the private-render behavior, so the watermark claims were verified against preview-deploy runtime logs (`PRERENDER → HIT → BYPASS → REVALIDATED`, never `STALE` from `updateTag`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
