### PR TITLE
perf(web): keep the Vercel Toolbar and a 404ing analytics tag out of production

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,4 +1,5 @@
 import { authMiddleware } from "@repo/auth/middleware";
+import { isToolbarEnabled } from "@repo/feature-flags/lib/toolbar-enabled";
 import { internationalizationMiddleware } from "@repo/internationalization/middleware";
 import { parseError } from "@repo/observability/error";
 import { secure } from "@repo/security";
@@ -20,7 +21,10 @@ export const config = {
   ],
 };
 
-const securityHeaders = env.FLAGS_SECRET
+// Only widen the CSP where the toolbar actually renders. Keying this on
+// FLAGS_SECRET alone meant production carried vercel.live allowances for a
+// toolbar it no longer loads.
+const securityHeaders = isToolbarEnabled()
   ? securityMiddleware(noseconeOptionsWithToolbar)
   : securityMiddleware(noseconeOptions);
 

--- a/packages/analytics/keys.ts
+++ b/packages/analytics/keys.ts
@@ -7,10 +7,18 @@ export const keys = () =>
       NEXT_PUBLIC_GA_MEASUREMENT_ID: z.string().startsWith("G-").optional(),
       NEXT_PUBLIC_POSTHOG_HOST: z.url(),
       NEXT_PUBLIC_POSTHOG_KEY: z.string().startsWith("phc_"),
+      /*
+       * Set to "true" only once Web Analytics is enabled for the project in
+       * the Vercel dashboard. The script lives at /_vercel/insights/script.js,
+       * a path the platform serves only for provisioned projects, so rendering
+       * the tag without it is a guaranteed 404.
+       */
+      NEXT_PUBLIC_VERCEL_ANALYTICS: z.literal("true").optional(),
     },
     runtimeEnv: {
       NEXT_PUBLIC_GA_MEASUREMENT_ID: process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
       NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
       NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+      NEXT_PUBLIC_VERCEL_ANALYTICS: process.env.NEXT_PUBLIC_VERCEL_ANALYTICS,
     },
   });

--- a/packages/analytics/provider.tsx
+++ b/packages/analytics/provider.tsx
@@ -7,18 +7,24 @@ interface AnalyticsProviderProps {
   readonly children: ReactNode;
 }
 
-const { NEXT_PUBLIC_GA_MEASUREMENT_ID } = keys();
+const { NEXT_PUBLIC_GA_MEASUREMENT_ID, NEXT_PUBLIC_VERCEL_ANALYTICS } = keys();
 
-// Vercel Analytics fetches its script from /_vercel/insights/script.js, a path
-// only the Vercel edge serves. Anywhere else — a local production build, a
-// container, any self-hosted deploy — the tag renders, 404s, and logs a console
-// error while collecting nothing. Render it only where it can actually work.
-const isOnVercel = Boolean(process.env.VERCEL);
+/*
+ * Vercel Analytics loads its script from /_vercel/insights/script.js, which
+ * the platform serves only for projects with Web Analytics enabled. Being
+ * deployed on Vercel is not enough — this project has never had it enabled, so
+ * the tag rendered on every production page view, 404ed, and logged a console
+ * error while collecting nothing. PostHog is already doing the analytics.
+ *
+ * Enabling Web Analytics is a dashboard toggle; set NEXT_PUBLIC_VERCEL_ANALYTICS
+ * to "true" at the same time to turn the tag back on.
+ */
+const vercelAnalyticsEnabled = NEXT_PUBLIC_VERCEL_ANALYTICS === "true";
 
 export const AnalyticsProvider = ({ children }: AnalyticsProviderProps) => (
   <>
     {children}
-    {isOnVercel ? <VercelAnalytics /> : null}
+    {vercelAnalyticsEnabled ? <VercelAnalytics /> : null}
     {NEXT_PUBLIC_GA_MEASUREMENT_ID ? (
       <GoogleAnalytics gaId={NEXT_PUBLIC_GA_MEASUREMENT_ID} />
     ) : null}

--- a/packages/feature-flags/components/toolbar.tsx
+++ b/packages/feature-flags/components/toolbar.tsx
@@ -1,8 +1,8 @@
 import dynamic from "next/dynamic";
-import { keys } from "../keys";
+import { isToolbarEnabled } from "../lib/toolbar-enabled";
 
 const VercelToolbar = dynamic(() =>
   import("@vercel/toolbar/next").then((mod) => mod.VercelToolbar)
 );
 
-export const Toolbar = () => (keys().FLAGS_SECRET ? <VercelToolbar /> : null);
+export const Toolbar = () => (isToolbarEnabled() ? <VercelToolbar /> : null);

--- a/packages/feature-flags/lib/toolbar-enabled.ts
+++ b/packages/feature-flags/lib/toolbar-enabled.ts
@@ -1,0 +1,23 @@
+import { keys } from "../keys";
+
+/**
+ * Whether the Vercel Toolbar should be wired up in this environment.
+ *
+ * The toolbar is a development instrument, but `FLAGS_SECRET` is set in every
+ * environment, so gating on it alone shipped the toolbar to production
+ * visitors: `feedback.js`, a `feedback.html` iframe, and a `fetch` of the
+ * page's own OG image — roughly 120 KB and three extra origins, on a surface
+ * only the team can log into. Preview is where flag overrides earn their keep,
+ * so the toolbar runs there and locally, and stays out of production.
+ *
+ * `VERCEL_ENV` is unset outside Vercel, which is what keeps it available in
+ * local development.
+ *
+ * This lives apart from `./toolbar` on purpose. That module reaches for
+ * `@vercel/toolbar/plugins/next`, a build-time plugin that drags in chokidar
+ * and the native fsevents binding; importing it from the proxy or a Server
+ * Component fails the Turbopack build with "non-ecmascript placeable asset".
+ * Runtime callers want this file, never that one.
+ */
+export const isToolbarEnabled = (): boolean =>
+  Boolean(keys().FLAGS_SECRET) && process.env.VERCEL_ENV !== "production";

--- a/packages/feature-flags/lib/toolbar.ts
+++ b/packages/feature-flags/lib/toolbar.ts
@@ -1,7 +1,13 @@
-import { keys } from "../keys";
+import { isToolbarEnabled } from "./toolbar-enabled";
 
+/**
+ * Build-time only. This pulls in `@vercel/toolbar/plugins/next`, which depends
+ * on chokidar and the native fsevents binding — import it from anywhere that
+ * gets bundled for the browser, the proxy or a Server Component and the
+ * Turbopack build fails. Runtime callers want `./toolbar-enabled`.
+ */
 export const withToolbar = async (config: object) => {
-  if (keys().FLAGS_SECRET) {
+  if (isToolbarEnabled()) {
     const { withVercelToolbar } = await import("@vercel/toolbar/plugins/next");
     return withVercelToolbar()(config);
   }


### PR DESCRIPTION
## What this fixes

Production (`https://www.hastoggle.dev/`, desktop preset) was **99 / 100 / 96 / 100**. Two causes, both real, both in the LCP window.

### Best Practices 96 → 100 (verified)

`/_vercel/insights/script.js` 404s. Root cause: **Web Analytics was never provisioned for this project** — the Vercel API returns `Web Analytics not found`. The platform only serves that path for enabled projects, so the tag could never do anything but 404.

The previous `process.env.VERCEL` gate was too weak: being deployed *on* Vercel doesn't mean the feature exists. It's now an explicit opt-in (`NEXT_PUBLIC_VERCEL_ANALYTICS`). PostHog already covers pageviews, autocapture and web vitals.

If you'd rather have it: enable Web Analytics in the dashboard and set the flag — both, or neither.

### Performance (expected, needs the deploy to confirm)

The Vercel Toolbar was loading for every production visitor. Measured on live production:

| Request | Start | Size |
|---|---|---|
| `vercel.live/…/feedback.js` | 210ms | 23 KB |
| `vercel.live/…/feedback.js` | 349ms | — |
| `/api/og?title=…` (fetched *by* the iframe) | 365ms | 62 KB |
| `vercel.live/…/feedback.html` | 374ms | 34 KB |

~119 KB and three origins, against an observed LCP of 413ms. `feedback.js` started at **210ms — before the app's own JS chunks at 214–217ms**, so it was taking bandwidth precisely when the hero needed it.

I can't verify the resulting score without a deploy; production LCP was 0.9s scoring 0.96, and this removes ~16% of the bytes in that window.

## Two things I found and did *not* change

1. **Production serves no CSP header at all.** `proxy.ts` ends with `return middlewareResponse || headersResponse`, and the i18n middleware always returns a rewrite response — so nosecone's headers are discarded on every request. `curl -sI https://www.hastoggle.dev/` shows `strict-transport-security` (from Vercel) and no `content-security-policy`. Pre-existing and unrelated to the Lighthouse gap, but it deserves its own fix rather than being smuggled into a perf PR. The CSP change here is correct and becomes effective once that's fixed.

2. **Switzer Semibold/Bold (~39 KB) are preloaded but never render on the landing page.** Tempting, but they *are* used on `/blog` and `/legal` (`font-extrabold`), and in `(counter)` and `/learn` (`font-semibold`/`font-bold`) on non-mono text. `next/font` preloads per-route, and the family is declared once at the root, so trimming them would give those pages synthesized fake-bold. Not worth 39 KB.

## Verification

```
VERCEL_ENV=production bun run build && VERCEL_ENV=production bun run start -- -p 3001
```
→ no `vercel.live` references, no `_vercel/insights` request, Best Practices 100.

198 tests, typecheck, Biome all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
