### PR TITLE
refactor(analytics): one switch for Vercel Analytics, not two

### DIFF
--- a/packages/analytics/keys.ts
+++ b/packages/analytics/keys.ts
@@ -7,18 +7,10 @@ export const keys = () =>
       NEXT_PUBLIC_GA_MEASUREMENT_ID: z.string().startsWith("G-").optional(),
       NEXT_PUBLIC_POSTHOG_HOST: z.url(),
       NEXT_PUBLIC_POSTHOG_KEY: z.string().startsWith("phc_"),
-      /*
-       * Set to "true" only once Web Analytics is enabled for the project in
-       * the Vercel dashboard. The script lives at /_vercel/insights/script.js,
-       * a path the platform serves only for provisioned projects, so rendering
-       * the tag without it is a guaranteed 404.
-       */
-      NEXT_PUBLIC_VERCEL_ANALYTICS: z.literal("true").optional(),
     },
     runtimeEnv: {
       NEXT_PUBLIC_GA_MEASUREMENT_ID: process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID,
       NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
       NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
-      NEXT_PUBLIC_VERCEL_ANALYTICS: process.env.NEXT_PUBLIC_VERCEL_ANALYTICS,
     },
   });

--- a/packages/analytics/provider.tsx
+++ b/packages/analytics/provider.tsx
@@ -7,24 +7,28 @@ interface AnalyticsProviderProps {
   readonly children: ReactNode;
 }
 
-const { NEXT_PUBLIC_GA_MEASUREMENT_ID, NEXT_PUBLIC_VERCEL_ANALYTICS } = keys();
+const { NEXT_PUBLIC_GA_MEASUREMENT_ID } = keys();
 
 /*
- * Vercel Analytics loads its script from /_vercel/insights/script.js, which
- * the platform serves only for projects with Web Analytics enabled. Being
- * deployed on Vercel is not enough — this project has never had it enabled, so
- * the tag rendered on every production page view, 404ed, and logged a console
- * error while collecting nothing. PostHog is already doing the analytics.
+ * Vercel Analytics loads its script from /_vercel/insights/script.js, a path
+ * only the Vercel edge serves. Anywhere else — a local production build, a
+ * container, any self-hosted deploy — the tag renders, 404s, and logs a
+ * console error while collecting nothing.
  *
- * Enabling Web Analytics is a dashboard toggle; set NEXT_PUBLIC_VERCEL_ANALYTICS
- * to "true" at the same time to turn the tag back on.
+ * This briefly sat behind an explicit NEXT_PUBLIC_VERCEL_ANALYTICS flag,
+ * because the path also 404s on Vercel until Web Analytics is enabled for the
+ * project, and nothing at runtime can tell you whether it has been. Web
+ * Analytics is now enabled, which makes the flag a second switch that has to
+ * agree with the dashboard — and when the two disagree the tag fails silently,
+ * collecting nothing while looking fine. A 404 at least announces itself.
+ * One switch is better: enable it in the dashboard and it works.
  */
-const vercelAnalyticsEnabled = NEXT_PUBLIC_VERCEL_ANALYTICS === "true";
+const isOnVercel = Boolean(process.env.VERCEL);
 
 export const AnalyticsProvider = ({ children }: AnalyticsProviderProps) => (
   <>
     {children}
-    {vercelAnalyticsEnabled ? <VercelAnalytics /> : null}
+    {isOnVercel ? <VercelAnalytics /> : null}
     {NEXT_PUBLIC_GA_MEASUREMENT_ID ? (
       <GoogleAnalytics gaId={NEXT_PUBLIC_GA_MEASUREMENT_ID} />
     ) : null}


### PR DESCRIPTION
## Why

I introduced `NEXT_PUBLIC_VERCEL_ANALYTICS` in #386 to stop a guaranteed 404 — Web Analytics had never been provisioned for this project, so the tag could only ever fail. Since nothing at runtime can detect provisioning, I made it an explicit assertion.

That was the wrong shape. It requires **two switches in two systems to agree**, and when they disagree it fails *silently*: you enable Web Analytics, the script starts serving, and you still collect nothing because the env var defaults off. That's exactly what happened here. I traded a loud failure for a quiet one.

## What changes

```diff
-const vercelAnalyticsEnabled = NEXT_PUBLIC_VERCEL_ANALYTICS === "true";
+const isOnVercel = Boolean(process.env.VERCEL);
```

Plus removing the key from `keys.ts`. The `process.env.VERCEL` gate keeps its original job — no 404 on local production builds or self-hosted deploys — without a second switch to keep in sync.

Net effect: enabling Web Analytics in the dashboard is now sufficient. No env var to set.

## Verification

Two production builds, checked in the browser:

| Build | `/_vercel/insights/script.js` | Console |
|---|---|---|
| `VERCEL=1` | requested | 1 error (local 404 — expected, that path only exists on Vercel) |
| no `VERCEL` | not requested | clean |

On production, where the path now serves 200, the first row is the working case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
