### PR TITLE
refactor(web): drop the mobile burger menu that opened onto nothing

### DIFF
--- a/apps/web/app/[locale]/components/navbar.tsx
+++ b/apps/web/app/[locale]/components/navbar.tsx
@@ -1,7 +1,3 @@
-"use client";
-
-import { Menu } from "lucide-react";
-import { useCallback, useState } from "react";
 import { Logo } from "./logo";
 import { Link } from "./marketing-link";
 import { PlusGrid, PlusGridItem, PlusGridRow } from "./plus-grid";
@@ -25,64 +21,6 @@ function DesktopNav({ variant }: { variant: "light" | "dark" }) {
   );
 }
 
-function MobileNavButton({
-  variant,
-  onClick,
-}: {
-  variant: "light" | "dark";
-  onClick: () => void;
-}) {
-  return (
-    <button
-      aria-label="Open main menu"
-      className="flex size-12 items-center justify-center self-center rounded-lg hover:bg-black/5 lg:hidden"
-      onClick={onClick}
-      type="button"
-    >
-      <Menu
-        className={`size-6 ${variant === "dark" ? "text-white" : "text-foreground"}`}
-      />
-    </button>
-  );
-}
-
-function MobileNav({
-  variant,
-  open,
-}: {
-  variant: "light" | "dark";
-  open: boolean;
-}) {
-  if (!open) {
-    return null;
-  }
-
-  return (
-    <div className="lg:hidden">
-      <div className="flex flex-col gap-6 py-4">
-        {links.map(({ href, label }) => (
-          <div key={href}>
-            <Link
-              className={`font-medium text-base ${variant === "dark" ? "text-white" : "text-foreground"}`}
-              href={href}
-            >
-              {label}
-            </Link>
-          </div>
-        ))}
-      </div>
-      <div className="absolute left-1/2 w-screen -translate-x-1/2">
-        <div
-          className={`absolute inset-x-0 top-0 border-t ${variant === "dark" ? "border-white/10" : "border-black/5"}`}
-        />
-        <div
-          className={`absolute inset-x-0 top-2 border-t ${variant === "dark" ? "border-white/10" : "border-black/5"}`}
-        />
-      </div>
-    </div>
-  );
-}
-
 export function Navbar({
   banner,
   variant = "light",
@@ -90,9 +28,6 @@ export function Navbar({
   banner?: React.ReactNode;
   variant?: "light" | "dark";
 }) {
-  const [open, setOpen] = useState(false);
-  const toggleMobileNav = useCallback(() => setOpen((current) => !current), []);
-
   return (
     <header className="pt-12 sm:pt-16">
       <PlusGrid>
@@ -116,10 +51,8 @@ export function Navbar({
             ) : null}
           </div>
           <DesktopNav variant={variant} />
-          <MobileNavButton onClick={toggleMobileNav} variant={variant} />
         </PlusGridRow>
       </PlusGrid>
-      <MobileNav open={open} variant={variant} />
     </header>
   );
 }


### PR DESCRIPTION
## What

On screens below `lg`, the landing page showed a burger button. The nav's `links` array is empty, so tapping it opened a blank panel and nothing else.

Removed:

- `MobileNavButton` (the burger) and `MobileNav` (the panel)
- The `open` / `toggleMobileNav` state, and with it the `useState` / `useCallback` and `Menu` imports
- The `"use client"` directive — nothing left in the file needs the client, so `Navbar` now renders on the server

`DesktopNav` and the empty `links` array stay. Adding nav links back is still a one-line change; it just won't come with a menu that opens onto nothing.

## Verification

- `bun run check` — clean
- `tsc --noEmit` on `apps/web` — clean
- `bun test` in `apps/web` — 198/198 pass
- Loaded the page at 390×844 in Chrome: header shows the logo only, no burger

🤖 Generated with [Claude Code](https://claude.com/claude-code)