### PR TITLE
feat(web): link the checkpoints repo from the footer, and mark what opens a tab

### DIFF
--- a/apps/web/app/[locale]/components/footer.tsx
+++ b/apps/web/app/[locale]/components/footer.tsx
@@ -14,20 +14,61 @@ function SitemapLinks({ children }: { children: React.ReactNode }) {
   return <ul className="mt-6 space-y-4 text-sm/6">{children}</ul>;
 }
 
-function SitemapLink(props: React.ComponentPropsWithoutRef<typeof Link>) {
+function ExternalIcon(props: React.ComponentPropsWithoutRef<"svg">) {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      {...props}
+    >
+      <path d="M15 3h6v6" />
+      <path d="M10 14 21 3" />
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h6" />
+    </svg>
+  );
+}
+
+function SitemapLink({
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof Link>) {
+  // The icon is derived from `target`, not passed in, so a link can never
+  // open a tab without saying so.
+  const opensNewTab = props.target === "_blank";
+
   return (
     <li>
       <Link
         {...props}
         className="font-medium text-foreground hover:text-foreground/75"
-      />
+      >
+        {children}
+        {opensNewTab && (
+          <>
+            {/* Inline, not a flex child: the column is narrow enough that
+                these labels wrap, and a flex icon parks itself beside the
+                whole wrapped block instead of following the last word. */}
+            <ExternalIcon className="ml-1 inline size-3 align-[-0.08em] opacity-60" />
+            {/* The glyph is the sighted half of this; screen readers get the
+                same fact in words rather than a shrug. */}
+            <span className="sr-only">(opens in a new tab)</span>
+          </>
+        )}
+      </Link>
     </li>
   );
 }
 
 function Sitemap() {
+  // Two columns wide because the longest label plus its icon overflows one,
+  // and the columns beside it are empty — the extra width costs nothing.
   return (
-    <div>
+    <div className="col-span-2">
       <SitemapHeading>Playground</SitemapHeading>
       <SitemapLinks>
         <SitemapLink href="/#faq">FAQs</SitemapLink>

--- a/apps/web/app/[locale]/components/footer.tsx
+++ b/apps/web/app/[locale]/components/footer.tsx
@@ -37,6 +37,12 @@ function Sitemap() {
         >
           Source on GitHub
         </SitemapLink>
+        <SitemapLink
+          href="https://github.com/hasToggle/hasToggle.dev-checkpoints"
+          target="_blank"
+        >
+          Prompts and checkpoints
+        </SitemapLink>
       </SitemapLinks>
     </div>
   );

--- a/apps/web/app/[locale]/components/hero.tsx
+++ b/apps/web/app/[locale]/components/hero.tsx
@@ -37,7 +37,14 @@ export function Hero() {
             style={{ "--ht-delay": "280ms" } as React.CSSProperties}
           >
             <MarketingButton href="#demo-01">Start poking</MarketingButton>
-            <MetaAside className="sm:max-w-xs">
+            {/* Block markers, not `//`: this one wraps to two lines, and a
+                line comment whose second line has no marker isn't a comment.
+                The exhibit asides wear this variant in comment-gray; the hero
+                keeps the meta-aside cyan, so only the markers change. */}
+            <MetaAside
+              className="text-ht-cyan-800/75 sm:max-w-xs dark:text-ht-cyan-300/85"
+              variant="comment"
+            >
               Nothing on this page is a mockup. We checked twice.
             </MetaAside>
           </div>

--- a/apps/web/app/[locale]/components/meta-aside.tsx
+++ b/apps/web/app/[locale]/components/meta-aside.tsx
@@ -17,16 +17,20 @@ export function MetaAside({
     // The exhibit asides, set the way they read: a note an engineer left in
     // this codebase. Comment-gray like the highlighted source's own comments,
     // wrapped in the block markers, no brand color asking for credit.
+    //
+    // The spaces beside the markers are U+00A0. A marker belongs to the text
+    // it wraps, and an ordinary space lets the closing marker wrap onto a line
+    // of its own, which is not a shape a comment ever has in an editor.
     return (
       <aside
         className={cn("font-mono text-muted-foreground text-sm/6", className)}
       >
         <span aria-hidden="true" className="select-none opacity-55">
-          {"/* "}
+          {"/* "}
         </span>
         {children}
         <span aria-hidden="true" className="select-none opacity-55">
-          {" */"}
+          {" */"}
         </span>
       </aside>
     );


### PR DESCRIPTION
The page names the prompts repo twice in prose — the FAQ and the built-in-the-open aside — but the footer only pointed at the source, and the GitHub icon duplicated that same link. This adds the second repo and makes both say that they open a new tab.

## The footer

```
Playground
  FAQs
  Source on GitHub        ↗   → hasToggle/hasToggle.dev
  Prompts and checkpoints ↗   → hasToggle/hasToggle.dev-checkpoints
```

Two rows rather than one slash-separated line: a `/` between two links puts adjacent tap targets ~4px apart, and screen readers don't announce it, so the pairing wouldn't survive to assistive tech anyway. Adjacency reads as a pair for free. The links now sit 40px apart top-to-top, well clear of the 24px floor in WCAG 2.5.8.

Labels use the words the page already uses for that repo (`every prompt and checkpoint published`, `even the prompts are public`) rather than `Prompts on GitHub`, which would have put "on GitHub" in two adjacent rows.

`SitemapLink` derives the external marker from `target === "_blank"` instead of taking a prop, so `FAQs` (an in-page anchor) stays bare and a future external link can't forget it. Each marked link also carries an `sr-only` "(opens in a new tab)".

Two layout notes:

- The icon flows **inline**, not as a flex child. A first pass with `inline-flex items-center` put the icon vertically centred beside the whole wrapped block when the label wrapped, instead of following the last word.
- The sitemap column spans two. With the icon added the longest label no longer fit one column and the glyph orphaned onto its own line; the three columns beside it were empty, so the width costs nothing.

The GitHub social icon still points at the main repo — two GitHub glyphs in that row would read as a bug.

## The hero comment

`Nothing on this page is a mockup. We checked twice.` wraps to two lines, and a `//` comment whose second line has no marker is not a comment. It takes the `/* … */` variant the exhibit asides already use, keeping the meta-aside cyan via `className` so only the markers change.

Both markers in `MetaAside` now sit against U+00A0: at 390px the closing `*/` wrapped onto a line by itself. That also lands on the five exhibit asides, which had the same latent orphan.

## Verification

- Biome and `tsc --noEmit` clean; 198/198 tests pass
- Screenshots at 1280×900 and 390×844 for hero and footer; all three sitemap links measure one line high at both widths
- Rendered HTML confirms both hrefs resolve to the right repos
- Exhibit asides re-checked for regression from the U+00A0 change

## Left alone, deliberately

- `section-link.tsx` uses a leading cyan `↗`, documented as "External reference in the instrument register". The footer uses the conventional box-and-arrow. Read as different registers — instrument vs. marketing chrome — but happy to unify on either if you'd rather the page spoke one glyph.
- `SectionLink` has no screen-reader equivalent for its `↗`, so every `↗ docs` / `↗ source` in the demo reference bars opens a tab silently. Pre-existing; a small separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)