### PR TITLE
feat(web): add a theme switch to the landing page

### DIFF
--- a/apps/web/app/[locale]/components/footer.tsx
+++ b/apps/web/app/[locale]/components/footer.tsx
@@ -6,7 +6,9 @@ import { PlusGrid, PlusGridItem, PlusGridRow } from "./plus-grid";
 
 function SitemapHeading({ children }: { children: React.ReactNode }) {
   return (
-    <h3 className="font-medium text-foreground/50 text-sm/6">{children}</h3>
+    // `/60`, not `/50`: the sitemap label sits on the footer's `bg-muted`
+    // band, where `/50` measures 3.67:1 at 14px against the 4.5:1 floor.
+    <h3 className="font-medium text-foreground/60 text-sm/6">{children}</h3>
   );
 }
 
@@ -206,7 +208,10 @@ export function Footer() {
               </PlusGridItem>
             </div>
             <div>
-              <div className="py-3 text-center text-muted-foreground text-sm/6">
+              {/* `text-foreground/60`, not `text-muted-foreground`: that
+                  token is tuned for the page background, and on this muted
+                  band it lands at 4.35:1 — just under the floor. */}
+              <div className="py-3 text-center text-foreground/60 text-sm/6">
                 Come back Monday. There&rsquo;ll be something new to poke.
               </div>
             </div>
@@ -217,9 +222,11 @@ export function Footer() {
             </div>
           </PlusGridRow>
         </PlusGrid>
-        {/* Full-strength muted-foreground, not /80: at 12px the faded variant
-            lands on 4.26:1 against bg-muted, under the 4.5:1 floor. */}
-        <div className="pb-10 text-center text-muted-foreground text-xs/5">
+        {/* Was full-strength `muted-foreground`, chosen over `/80` to clear
+            the 4.5:1 floor. It did not: measured against this band the solid
+            token is 4.35:1, so the earlier fix moved in the right direction
+            and stopped short. `text-foreground/60` is 5.11:1. */}
+        <div className="pb-10 text-center text-foreground/60 text-xs/5">
           hasToggle is an independent project, not affiliated with or endorsed
           by Vercel. Next.js and Vercel are trademarks of Vercel, Inc.
         </div>

--- a/apps/web/app/[locale]/components/hero.tsx
+++ b/apps/web/app/[locale]/components/hero.tsx
@@ -42,7 +42,7 @@ export function Hero() {
                 The exhibit asides wear this variant in comment-gray; the hero
                 keeps the meta-aside cyan, so only the markers change. */}
             <MetaAside
-              className="text-ht-cyan-800/75 sm:max-w-xs dark:text-ht-cyan-300/85"
+              className="text-ht-cyan-900 sm:max-w-xs dark:text-ht-cyan-300/85"
               variant="comment"
             >
               Nothing on this page is a mockup. We checked twice.

--- a/apps/web/app/[locale]/components/meta-aside.tsx
+++ b/apps/web/app/[locale]/components/meta-aside.tsx
@@ -40,7 +40,7 @@ export function MetaAside({
     return (
       <aside
         className={cn(
-          "border-ht-cyan-700/30 border-l-2 pl-4 font-mono text-ht-cyan-900/70 text-sm/6 dark:border-ht-cyan-500/40 dark:text-ht-cyan-300/85",
+          "border-ht-cyan-700/30 border-l-2 pl-4 font-mono text-ht-cyan-900 text-sm/6 dark:border-ht-cyan-500/40 dark:text-ht-cyan-300/85",
           className
         )}
       >
@@ -52,7 +52,13 @@ export function MetaAside({
   return (
     <p
       className={cn(
-        "font-mono text-ht-cyan-800/75 text-sm/6 dark:text-ht-cyan-300/85",
+        // Solid cyan-900, not the 800/75 and 900/70 these started on. At
+        // 14px the aside needs 4.5:1 and those measured 3.00 and 3.48 on the
+        // page's own white. Every faded cyan this palette can make misses —
+        // 900/85 is the closest and still lands at 4.46 on the muted band.
+        // Solid 900 clears it everywhere the component is used (6.03 worst
+        // case). Dark keeps 300/85, which was never in question at 12.62.
+        "font-mono text-ht-cyan-900 text-sm/6 dark:text-ht-cyan-300/85",
         className
       )}
     >

--- a/apps/web/app/[locale]/components/navbar.tsx
+++ b/apps/web/app/[locale]/components/navbar.tsx
@@ -1,6 +1,7 @@
 import { Logo } from "./logo";
 import { Link } from "./marketing-link";
 import { PlusGrid, PlusGridItem, PlusGridRow } from "./plus-grid";
+import { ThemeSwitch } from "./theme-switch";
 
 const links: { href: string; label: string }[] = [];
 
@@ -50,7 +51,11 @@ export function Navbar({
               </div>
             ) : null}
           </div>
-          <DesktopNav variant={variant} />
+          {/* The corner every editor keeps its view switches in. */}
+          <div className="relative flex items-center gap-6">
+            <DesktopNav variant={variant} />
+            <ThemeSwitch variant={variant} />
+          </div>
         </PlusGridRow>
       </PlusGrid>
     </header>

--- a/apps/web/app/[locale]/components/theme-switch.tsx
+++ b/apps/web/app/[locale]/components/theme-switch.tsx
@@ -16,39 +16,9 @@ const OPTIONS = [
   { Icon: MonitorIcon, label: "system", value: "system" },
 ] as const;
 
-// The collapsed box is reserved at the longest label's width, so the row's
-// layout never depends on which theme happens to be active. Derived rather
-// than named, so renaming an option keeps the reservation honest.
-const WIDEST = OPTIONS.reduce((widest, option) =>
-  option.label.length > widest.label.length ? option : widest
-);
-
 // One group on the page, so a literal name is enough and beats a generated
 // id that would have to survive the mount gate below.
 const GROUP = "theme";
-
-// Horizontal padding is left out: the resting chip wears it, the folded ones
-// drop it to zero so they collapse to nothing instead of to 20px of air.
-const CHIP =
-  "flex items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-full py-1 font-mono font-semibold text-[0.7rem] uppercase tracking-[0.16em]";
-
-// Written out rather than interpolated from a shared string: Tailwind scans
-// the source for whole class names, and `group-hover:${OPEN}` produces none.
-const OPEN = "max-w-40 px-2.5 opacity-100";
-const FOLDED = cn(
-  "max-w-0 px-0 opacity-0",
-  "group-hover:max-w-40 group-hover:px-2.5 group-hover:opacity-100",
-  "group-focus-within:max-w-40 group-focus-within:px-2.5 group-focus-within:opacity-100"
-);
-
-function ChipContent({ Icon, label }: { Icon: typeof SunIcon; label: string }) {
-  return (
-    <>
-      <Icon aria-hidden="true" className="size-3.5 shrink-0" strokeWidth={2} />
-      {label}
-    </>
-  );
-}
 
 function ThemeOption({
   Icon,
@@ -68,10 +38,7 @@ function ThemeOption({
     <label className="cursor-pointer">
       {/* A real radio group: the platform gives one tab stop, arrow-key
           movement between the three, and the right role and checked state
-          without a line of keyboard code here. The folded options stay in
-          the DOM and stay focusable — they are clipped, not removed, so a
-          screen reader is told about all three whatever the pointer is
-          doing. */}
+          without a line of keyboard code here. */}
       <input
         checked={selected}
         className="peer sr-only"
@@ -82,8 +49,10 @@ function ThemeOption({
       />
       <span
         className={cn(
-          CHIP,
-          "motion-safe:transition-[max-width,padding,opacity] motion-safe:duration-200",
+          // `py-1.5`, not `py-1`: with the labels hidden below `sm` these are
+          // 34px-wide icon chips, and `py-1` left them 22px tall — under the
+          // 24px floor WCAG 2.5.8 puts on a touch target.
+          "flex items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 py-1.5 font-mono font-semibold text-[0.7rem] uppercase tracking-[0.16em] transition-colors",
           "peer-focus-visible:outline-2 peer-focus-visible:outline-ht-cyan-600 peer-focus-visible:outline-offset-2 dark:peer-focus-visible:outline-ht-cyan-400",
           selected
             ? // The active chip is the filled one, and the pill behind it
@@ -91,36 +60,43 @@ function ThemeOption({
               // instead reads as raised in light mode and sunken in dark,
               // where the page is darker than `bg-muted` rather than
               // lighter.
-              cn(OPEN, "bg-muted text-foreground")
-            : // Hover for the mouse, focus-within for the keyboard and for
-              // the tap that lands on the resting chip. Hover alone would
-              // make this unreachable on the phone — which is the width that
-              // wanted it folded in the first place.
-              cn(FOLDED, "text-muted-foreground hover:text-foreground")
+              "bg-muted text-foreground"
+            : "text-muted-foreground hover:text-foreground"
         )}
       >
-        <ChipContent Icon={Icon} label={label} />
+        <Icon
+          aria-hidden="true"
+          className="size-3.5 shrink-0"
+          strokeWidth={2}
+        />
+        {/* `sr-only`, not `hidden`: below `sm` there is no room beside the
+            wordmark for three labels, but a display-none label would take
+            the radio's accessible name down with it. This keeps the word in
+            the a11y tree at every width and only stops painting it. */}
+        <span className="sr-only sm:not-sr-only">{label}</span>
       </span>
     </label>
   );
 }
 
 /**
- * The theme control: light, dark, or follow the OS. At rest it shows only the
- * mode in force — a readout that happens to be pressable, the same move the
- * exhibits' state gauge makes. Hover, focus or tap it and the other two
- * unfold to its left.
+ * The theme control: light, dark, or follow the OS. All three positions are
+ * visible at once — which one is active is the fact worth showing, and one
+ * click is the whole interaction.
  *
- * The unfolding is an overlay, not a reflow. Expanded, the group is wider
- * than the gap between the wordmark and the right edge on a phone, so laying
- * it out in flow would shove the logo around every time a pointer crossed
- * it. An invisible box holds the resting footprint; the group itself is
- * absolute and opaque, and passes over the logo when it opens.
+ * Nothing here moves or unfolds. An earlier version collapsed to the active
+ * mode and expanded on hover, which shifted the active chip up to 165px
+ * sideways for two of the three modes: the group is pinned to the right
+ * edge, so only the last option in the row can hold still while the others
+ * appear. Below `sm` the labels go quiet instead, which buys the same width
+ * without moving anything.
  *
  * It renders nothing until mounted. The choice lives in localStorage, so the
  * server cannot know it — a server-rendered control would either mark the
  * wrong option for a frame or, with JavaScript off, sit there being a switch
- * that switches nothing.
+ * that switches nothing. Nothing shifts when it appears: the row is
+ * `justify-between` with the logo setting its height, so this arrives in
+ * empty space at the right edge.
  */
 export function ThemeSwitch({
   variant = "light",
@@ -140,37 +116,25 @@ export function ThemeSwitch({
 
   return (
     <PlusGridItem className="py-3" variant={variant}>
-      <div className="group relative flex justify-end">
-        {/* Reserves the resting footprint. Same nesting as the real group so
-            the two boxes agree without either one hardcoding a width. */}
-        <div
-          aria-hidden="true"
-          className="invisible flex rounded-full border p-0.5"
-        >
-          <span className={cn(CHIP, "px-2.5")}>
-            <ChipContent Icon={WIDEST.Icon} label={WIDEST.label} />
-          </span>
-        </div>
-        {/* An explicit radiogroup rather than a fieldset: `sr-only` positions
-            the legend absolutely, and Chrome then stops treating it as the
-            fieldset's name — the word "Theme" ends up loose in the a11y tree
-            instead of labelling the group. The radios' shared `name` is what
-            gives the arrow keys their behaviour, so nothing is lost here. */}
-        <div
-          aria-label="Theme"
-          className="absolute top-0 right-0 z-20 flex items-center rounded-full border border-foreground/10 bg-background p-0.5"
-          role="radiogroup"
-        >
-          {OPTIONS.map((option) => (
-            <ThemeOption
-              Icon={option.Icon}
-              key={option.value}
-              label={option.label}
-              selected={theme === option.value}
-              value={option.value}
-            />
-          ))}
-        </div>
+      {/* An explicit radiogroup rather than a fieldset: `sr-only` positions
+          the legend absolutely, and Chrome then stops treating it as the
+          fieldset's name — the word "Theme" ends up loose in the a11y tree
+          instead of labelling the group. The radios' shared `name` is what
+          gives the arrow keys their behaviour, so nothing is lost here. */}
+      <div
+        aria-label="Theme"
+        className="flex items-center rounded-full border border-foreground/10 bg-background p-0.5"
+        role="radiogroup"
+      >
+        {OPTIONS.map((option) => (
+          <ThemeOption
+            Icon={option.Icon}
+            key={option.value}
+            label={option.label}
+            selected={theme === option.value}
+            value={option.value}
+          />
+        ))}
       </div>
     </PlusGridItem>
   );

--- a/apps/web/app/[locale]/components/theme-switch.tsx
+++ b/apps/web/app/[locale]/components/theme-switch.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { cn } from "@repo/design-system/lib/utils";
+import { useTheme } from "@repo/design-system/providers/theme";
+import { MonitorIcon, MoonIcon, SunIcon } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { PlusGridItem } from "./plus-grid";
+
+// The symbols everyone already reads as these three things. They carry the
+// meaning for a visitor scanning the corner; the words carry it for anyone
+// who finds a sun and a monitor ambiguous. Two channels, one control — the
+// redundancy design.md asks for instead of a per-audience mode.
+const OPTIONS = [
+  { Icon: SunIcon, label: "light", value: "light" },
+  { Icon: MoonIcon, label: "dark", value: "dark" },
+  { Icon: MonitorIcon, label: "system", value: "system" },
+] as const;
+
+// The collapsed box is reserved at the longest label's width, so the row's
+// layout never depends on which theme happens to be active. Derived rather
+// than named, so renaming an option keeps the reservation honest.
+const WIDEST = OPTIONS.reduce((widest, option) =>
+  option.label.length > widest.label.length ? option : widest
+);
+
+// One group on the page, so a literal name is enough and beats a generated
+// id that would have to survive the mount gate below.
+const GROUP = "theme";
+
+// Horizontal padding is left out: the resting chip wears it, the folded ones
+// drop it to zero so they collapse to nothing instead of to 20px of air.
+const CHIP =
+  "flex items-center gap-1.5 overflow-hidden whitespace-nowrap rounded-full py-1 font-mono font-semibold text-[0.7rem] uppercase tracking-[0.16em]";
+
+// Written out rather than interpolated from a shared string: Tailwind scans
+// the source for whole class names, and `group-hover:${OPEN}` produces none.
+const OPEN = "max-w-40 px-2.5 opacity-100";
+const FOLDED = cn(
+  "max-w-0 px-0 opacity-0",
+  "group-hover:max-w-40 group-hover:px-2.5 group-hover:opacity-100",
+  "group-focus-within:max-w-40 group-focus-within:px-2.5 group-focus-within:opacity-100"
+);
+
+function ChipContent({ Icon, label }: { Icon: typeof SunIcon; label: string }) {
+  return (
+    <>
+      <Icon aria-hidden="true" className="size-3.5 shrink-0" strokeWidth={2} />
+      {label}
+    </>
+  );
+}
+
+function ThemeOption({
+  Icon,
+  label,
+  selected,
+  value,
+}: {
+  Icon: typeof SunIcon;
+  label: string;
+  selected: boolean;
+  value: string;
+}) {
+  const { setTheme } = useTheme();
+  const select = useCallback(() => setTheme(value), [setTheme, value]);
+
+  return (
+    <label className="cursor-pointer">
+      {/* A real radio group: the platform gives one tab stop, arrow-key
+          movement between the three, and the right role and checked state
+          without a line of keyboard code here. The folded options stay in
+          the DOM and stay focusable — they are clipped, not removed, so a
+          screen reader is told about all three whatever the pointer is
+          doing. */}
+      <input
+        checked={selected}
+        className="peer sr-only"
+        name={GROUP}
+        onChange={select}
+        type="radio"
+        value={value}
+      />
+      <span
+        className={cn(
+          CHIP,
+          "motion-safe:transition-[max-width,padding,opacity] motion-safe:duration-200",
+          "peer-focus-visible:outline-2 peer-focus-visible:outline-ht-cyan-600 peer-focus-visible:outline-offset-2 dark:peer-focus-visible:outline-ht-cyan-400",
+          selected
+            ? // The active chip is the filled one, and the pill behind it
+              // takes the page colour. Filling it with `bg-background`
+              // instead reads as raised in light mode and sunken in dark,
+              // where the page is darker than `bg-muted` rather than
+              // lighter.
+              cn(OPEN, "bg-muted text-foreground")
+            : // Hover for the mouse, focus-within for the keyboard and for
+              // the tap that lands on the resting chip. Hover alone would
+              // make this unreachable on the phone — which is the width that
+              // wanted it folded in the first place.
+              cn(FOLDED, "text-muted-foreground hover:text-foreground")
+        )}
+      >
+        <ChipContent Icon={Icon} label={label} />
+      </span>
+    </label>
+  );
+}
+
+/**
+ * The theme control: light, dark, or follow the OS. At rest it shows only the
+ * mode in force — a readout that happens to be pressable, the same move the
+ * exhibits' state gauge makes. Hover, focus or tap it and the other two
+ * unfold to its left.
+ *
+ * The unfolding is an overlay, not a reflow. Expanded, the group is wider
+ * than the gap between the wordmark and the right edge on a phone, so laying
+ * it out in flow would shove the logo around every time a pointer crossed
+ * it. An invisible box holds the resting footprint; the group itself is
+ * absolute and opaque, and passes over the logo when it opens.
+ *
+ * It renders nothing until mounted. The choice lives in localStorage, so the
+ * server cannot know it — a server-rendered control would either mark the
+ * wrong option for a frame or, with JavaScript off, sit there being a switch
+ * that switches nothing.
+ */
+export function ThemeSwitch({
+  variant = "light",
+}: {
+  variant?: "light" | "dark";
+}) {
+  const { theme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  return (
+    <PlusGridItem className="py-3" variant={variant}>
+      <div className="group relative flex justify-end">
+        {/* Reserves the resting footprint. Same nesting as the real group so
+            the two boxes agree without either one hardcoding a width. */}
+        <div
+          aria-hidden="true"
+          className="invisible flex rounded-full border p-0.5"
+        >
+          <span className={cn(CHIP, "px-2.5")}>
+            <ChipContent Icon={WIDEST.Icon} label={WIDEST.label} />
+          </span>
+        </div>
+        {/* An explicit radiogroup rather than a fieldset: `sr-only` positions
+            the legend absolutely, and Chrome then stops treating it as the
+            fieldset's name — the word "Theme" ends up loose in the a11y tree
+            instead of labelling the group. The radios' shared `name` is what
+            gives the arrow keys their behaviour, so nothing is lost here. */}
+        <div
+          aria-label="Theme"
+          className="absolute top-0 right-0 z-20 flex items-center rounded-full border border-foreground/10 bg-background p-0.5"
+          role="radiogroup"
+        >
+          {OPTIONS.map((option) => (
+            <ThemeOption
+              Icon={option.Icon}
+              key={option.value}
+              label={option.label}
+              selected={theme === option.value}
+              value={option.value}
+            />
+          ))}
+        </div>
+      </div>
+    </PlusGridItem>
+  );
+}

--- a/apps/web/app/[locale]/components/theme-switch.tsx
+++ b/apps/web/app/[locale]/components/theme-switch.tsx
@@ -53,14 +53,22 @@ function ThemeOption({
           // 34px-wide icon chips, and `py-1` left them 22px tall — under the
           // 24px floor WCAG 2.5.8 puts on a touch target.
           "flex items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 py-1.5 font-mono font-semibold text-[0.7rem] uppercase tracking-[0.16em] transition-colors",
-          "peer-focus-visible:outline-2 peer-focus-visible:outline-ht-cyan-600 peer-focus-visible:outline-offset-2 dark:peer-focus-visible:outline-ht-cyan-400",
+          // cyan-700 in light, not the 600 this started on: 600 measures
+          // 2.32:1 against a white page, under the 3:1 WCAG 1.4.11 asks of a
+          // focus indicator. 700 is the first step that clears it (3.22:1)
+          // and still reads as the brand cyan — 800 passes wider but goes
+          // teal. Dark keeps 400, which is already 13.95:1 on this page.
+          "peer-focus-visible:outline-2 peer-focus-visible:outline-ht-cyan-700 peer-focus-visible:outline-offset-2 dark:peer-focus-visible:outline-ht-cyan-400",
           selected
-            ? // The active chip is the filled one, and the pill behind it
-              // takes the page colour. Filling it with `bg-background`
-              // instead reads as raised in light mode and sunken in dark,
-              // where the page is darker than `bg-muted` rather than
-              // lighter.
-              "bg-muted text-foreground"
+            ? // Inverted, not a tinted fill. `--muted` sits 1.09:1 from
+              // `--background`, so every subtle grey this palette can make
+              // leaves the selected state under the 3:1 WCAG 1.4.11 wants —
+              // `foreground/30` tops out at 2.05:1. Inverting clears it at
+              // 19.8:1 and borrows the treatment MarketingButton already
+              // uses: a black pill in light, a white one in dark. It matters
+              // most below `sm`, where the labels are hidden and the fill is
+              // most of what says which mode is on.
+              "bg-foreground text-background"
             : "text-muted-foreground hover:text-foreground"
         )}
       >

--- a/packages/design-system/providers/theme.tsx
+++ b/packages/design-system/providers/theme.tsx
@@ -1,5 +1,15 @@
 import type { ThemeProviderProps } from "next-themes";
-import { ThemeProvider as NextThemeProvider } from "next-themes";
+import {
+  ThemeProvider as NextThemeProvider,
+  useTheme as useNextTheme,
+} from "next-themes";
+
+// Handed on so consumers read the theme through the same module instance that
+// provides it. next-themes keeps its context in module scope, and an app that
+// depended on next-themes directly could resolve a second copy whose context
+// is permanently empty. Bound to a const rather than re-exported with
+// `export ... from`, which reads as a barrel file to the linter.
+export const useTheme = useNextTheme;
 
 export const ThemeProvider = ({
   children,


### PR DESCRIPTION
The landing page has had a light and a dark mode all along — `DesignSystemProvider` wires up next-themes with `defaultTheme="system"` — but no way to choose between them. This adds the control, then fixes the contrast problems the audit turned up along the way.

## The control

Three native radios styled as a segmented control, in the navbar's right corner — the spot `design.md` reserves for view controls, and the only empty part of that row. The platform gives one tab stop, arrow-key movement and the correct roles for free; the whole thing is about a kilobyte of client JS.

Not the design system's existing `ModeToggle`: it is a Radix dropdown, so it costs two clicks, never shows which theme is active, and would put `dropdown-menu` on a page that was recently tuned to Lighthouse 100. Its sun/moon icon cannot express "system" at all.

It renders nothing until mounted. The choice lives in localStorage, so a server-rendered control would either mark the wrong option for a frame or, with JavaScript off, be a switch that switches nothing.

Below `sm` the labels go quiet and the three icons remain, which keeps the control clear of the wordmark at 390px. They are `sr-only`, not `hidden` — `display: none` would take each radio's accessible name down with it. Verified: all three radios still read LIGHT / DARK / SYSTEM in the a11y tree at 390px.

## A false start worth recording

The first version folded down to the active mode and unfolded on hover. It moved the active chip **165px left** when `light` was active, **91px** when `dark`, and **0px** when `system` was — the group is pinned to the right edge, so only the last option in the row can hold still while the others appear beside it. Not tunable: holding `light` in place would need the other two to unfold to its right, off the edge of the container. The fold is gone.

## Contrast

Everything below was measured in Chrome by compositing each layer over the one beneath it. Compositing against white instead — the obvious shortcut — silently inverts every dark-mode reading.

On the control itself:

- **Focus ring, light mode: 2.32 → 3.22.** `ht-cyan-600` on a white page is under the 3:1 WCAG 1.4.11 asks of a focus indicator. `ht-cyan-700` is the first step that clears it and still reads as the brand cyan; 800 passes wider but goes teal. Dark keeps 400 at 13.95.
- **Selected state: 1.09 → 19.80 light, 1.31 → 18.97 dark.** `--muted` sits only 1.09:1 from `--background`, so no subtle grey in this palette can reach the 3:1 a state indicator needs — `foreground/30` tops out at 2.05. The chip inverts instead, which is the treatment `MarketingButton` already uses in each mode. This matters most below `sm`, where the labels are hidden and the fill carries nearly all of the signal; that case was the weakest of the audit at 2.48:1.
- Touch targets are 34×26, over the 24×24 floor in WCAG 2.5.8.

Deliberately left alone: the pill's `border-foreground/10` boundary at 1.25:1. It is the same edge `LivePanel` and the rest of the page use.

## Pre-existing failures fixed on the way

Lighthouse accessibility was **97**, failing `color-contrast` on seven nodes, none of them this control. It is **100** now, no failing audits.

| Element | Was | Now |
|---|---|---|
| Hero + FAQ asides (`ht-cyan-800/75`) | 3.00 | 6.03 |
| Hero footnote block (`ht-cyan-900/70`) | 3.48 | 6.03 |
| Footer sitemap label (`foreground/50`) | 3.67 | 5.11 |
| Footer marginalia ×2 (`muted-foreground`) | 4.35 | 5.11 |

The asides had to go solid `ht-cyan-900`: `900/85` is the closest near-miss and still lands at 4.46 on the footer's muted band, and `MetaAside` is shared enough to land on either backdrop. Dark keeps `300/85` and was never in question.

The footer comment claiming full-strength `muted-foreground` had been chosen to clear the floor was wrong — solid measures 4.35 against that band. It now says so.

## Known, not addressed

A stricter sweep than Lighthouse's finds more pre-existing failures: chapter numerals and provenance labels at 2.30 light / 3.40 dark, filename labels at 2.67, the code block's syntax theme at 3.05 in dark across 26 nodes, stream timings at 3.51. Most of that is deliberate instrument quietness per `design.md`, and the code blocks are a third-party syntax theme — changing them is a design decision about the instrument grammar rather than a bug sweep, so it is left for its own round.

## Verification

- Lighthouse accessibility 100 / best practices 100 / SEO 100
- 198/198 tests, Biome and `tsc` clean, `turbo build --filter=web` passes
- Keyboard: one Tab lands on the checked radio, arrows move and apply immediately
- 0px shift on focus for all three modes; group width constant at 254px whichever is active
- No console errors or hydration warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)