### PR TITLE
chore(entire): redact PII and lift images out of transcripts

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -6,5 +6,13 @@
       "repo": "hasToggle/hasToggle.dev-checkpoints"
     }
   },
-  "telemetry": false
+  "telemetry": false,
+  "redaction": {
+    "pii": {
+      "enabled": true,
+      "email": true,
+      "phone": true
+    },
+    "externalize_images": true
+  }
 }


### PR DESCRIPTION
The checkpoint repo (`hasToggle/hasToggle.dev-checkpoints`) is public, so
everything Entire persists is public. Two forward-only redaction settings.
Neither touches existing checkpoints.

## What changed

```json
"redaction": {
  "pii": { "enabled": true, "email": true, "phone": true },
  "externalize_images": true
}
```

**`redaction.pii`** — off by default. The contact form and the newsletter mean
real addresses can reach a transcript. Redaction runs *before* the checkpoint is
written, so the agent still reads and writes PII in the live session; only the
persisted record is scrubbed. `pii.address` stays off: it matches US street
addresses, which is no use from Osnabrück. German addresses would need
`pii.custom_patterns`.

**`redaction.externalize_images`** — this is bloat control, **not** privacy. It
moves base64 images out of `full.jsonl` into the checkpoint's `assets/` store,
and that store is pushed too, unredacted — `security.md` is explicit: *"None.
Every layer skips the assets subtree."* 177 of 480 transcripts carry inline
screenshots; some transcripts run to 19 MB. Nothing here removes an
already-published screenshot.

## Not enabled

`redaction.goredact` — CLI 0.10.2 uses Betterleaks and ignores scanner
selection; it first appears in `v0.10.3-nightly.202608210613.680d64782`. Worth
revisiting after a CLI bump. Note the guardrail: Entire **refuses to load
settings** when both scanners are disabled, so don't flip Betterleaks off while
adding goredact.

## Context

This came out of investigating why entire.io showed no sessions. Root cause was
unrelated — the Entire GitHub App wasn't installed on this repo, so the
`Entire-Checkpoint:` trailers on our commits had nothing to join against. That's
fixed (50 sessions now indexed). While auditing the public checkpoint corpus for
secret exposure I found none — every live value in `apps/web/.env.local` is
clean against all 480 transcripts; the only hits were `NEXT_PUBLIC_*` values and
the from-address, all public by design. The image gap is the one real residual,
and it is not closed by this PR.

## Verification

- `entire status` exits 0 — a malformed `redaction` block makes it refuse to load
- `entire checkpoint list` still reads all 72 checkpoints on the source branch

Config-only; no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)